### PR TITLE
Add helper auth guard role check

### DIFF
--- a/SLFrontend/src/app/app.routes.ts
+++ b/SLFrontend/src/app/app.routes.ts
@@ -20,6 +20,7 @@ import { AdminHelperViewComponent } from './admin-helper-view/admin-helper-view.
 import { HelperFormComponent } from './helper-form/helper-form.component';
 import { ConfirmationComponent } from './confirmation/confirmation.component';
 import { authGuard } from './auth.guard';
+import { helperAuthGuard } from './helper-auth.guard';
 import { UnauthorizedComponent } from './unauthorized/unauthorized.component';
 import { NotificationOnboardingComponent } from './notification-onboarding/notification-onboarding.component';
 import { NoticeComponent } from './notice/notice.component';
@@ -47,10 +48,11 @@ export const routes: Routes = [
     { path: 'unauthorized', component: UnauthorizedComponent },
     {path:'confirmationOnboarding',component:NotificationOnboardingComponent},
     {path:'onboardingcompleted',component:NoticeComponent},
-   { path: 'helper-dashboard', 
-    component: HelperDashboardComponent,
-    
-    children: [
+ { path: 'helper-dashboard',
+  component: HelperDashboardComponent,
+  canActivate: [helperAuthGuard],
+
+  children: [
       { path: 'profile', component: ProfileComponent },
       { path: 'agenda', component: AgendaComponent },
       { path: 'dashboard', component: DashboardComponent },

--- a/SLFrontend/src/app/helper-auth.guard.ts
+++ b/SLFrontend/src/app/helper-auth.guard.ts
@@ -1,0 +1,23 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from './services/auth.service';
+import { of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+
+export const helperAuthGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  return authService.getCurrentUser().pipe(
+    map(user => {
+      console.log('User from API:', user);
+      if (user && user.role === '3rd Party') {
+        return true;
+      }
+      return router.createUrlTree(['/helper-signin']);
+    }),
+    catchError(() => {
+      return of(router.createUrlTree(['/helper-signin']));
+    })
+  );
+};

--- a/SLFrontend/src/main.ts
+++ b/SLFrontend/src/main.ts
@@ -28,6 +28,7 @@ import { AdminHelperViewComponent } from './app/admin-helper-view/admin-helper-v
 import { HelperFormComponent } from './app/helper-form/helper-form.component';
 import { ConfirmationComponent } from './app/confirmation/confirmation.component';
 import { authGuard } from './app/auth.guard';
+import { helperAuthGuard } from './app/helper-auth.guard';
 import { UnauthorizedComponent } from './app/unauthorized/unauthorized.component';
 import { CsrfInterceptor } from './app/interceptors/csrf.service';
 import { NotificationOnboardingComponent } from './app/notification-onboarding/notification-onboarding.component';
@@ -42,8 +43,9 @@ const routes: Routes = [
   { path: 'signuphelper', component: SignuphelperComponent },
   { path: 'notifications', component: NotificationsComponent },
   { path: 'signin', component: SigninComponent },
-   { path: 'helper-dashboard', 
+   { path: 'helper-dashboard',
       component: HelperDashboardComponent,
+      canActivate: [helperAuthGuard],
       children: [
         { path: 'profile', component: ProfileComponent },
         { path: 'agenda', component: AgendaComponent },


### PR DESCRIPTION
## Summary
- enforce helper guard to verify users with `3rd Party` role
- keep helper dashboard route protected in module and standalone routing

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ab77bef088322ad997f2b63bd2b87