### PR TITLE
Add My Work section to helper dashboard

### DIFF
--- a/SLFrontend/src/app/helper-dashboard/dashboard/dashboard.component.css
+++ b/SLFrontend/src/app/helper-dashboard/dashboard/dashboard.component.css
@@ -170,3 +170,35 @@
   height: 100% !important;
   display: block;
 }
+
+/* My Work section */
+.my-work {
+  background: white;
+  padding: 1rem;
+  border-radius: 10px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.period-filters {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.orders-log {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.orders-log th,
+.orders-log td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.orders-log th {
+  background-color: #f3f4f6;
+}
+

--- a/SLFrontend/src/app/helper-dashboard/dashboard/dashboard.component.html
+++ b/SLFrontend/src/app/helper-dashboard/dashboard/dashboard.component.html
@@ -25,8 +25,48 @@
             <canvas #incomeChart style="height: 300px; width: 100%;"></canvas>
 
           </div>
-        
-          
+          <div class="my-work">
+            <h3>My Work</h3>
+            <div class="period-filters">
+              <label><input type="radio" name="period" value="today" [(ngModel)]="selectedFilter" (change)="applyFilter()"> Today</label>
+              <label><input type="radio" name="period" value="all" [(ngModel)]="selectedFilter" (change)="applyFilter()"> All</label>
+              <label>From <input type="date" [(ngModel)]="fromDate" (change)="selectedFilter='range';applyFilter()"></label>
+              <label>To <input type="date" [(ngModel)]="toDate" (change)="selectedFilter='range';applyFilter()"></label>
+            </div>
+
+            <div class="summary">
+              <p><strong>Base Rate:</strong> {{ baseRate | currency:'CAD':'symbol':'1.2-2' }}</p>
+              <p><strong>Total Work Orders:</strong> {{ summary.totalWorkOrders }}</p>
+              <p><strong>Confirmed Hours:</strong> {{ summary.confirmedHours | number:'1.2-2' }}</p>
+              <p><strong>Base Payouts:</strong> {{ summary.basePayouts | currency:'CAD':'symbol':'1.2-2' }}</p>
+              <p><strong>ISF:</strong> {{ summary.isf | currency:'CAD':'symbol':'1.2-2' }}</p>
+              <p><strong>Work Expenses:</strong> {{ summary.workExpenses | currency:'CAD':'symbol':'1.2-2' }}</p>
+            </div>
+
+            <table class="orders-log" *ngIf="filteredOrders.length > 0">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Adresse</th>
+                  <th>Confirmed Hours</th>
+                  <th>Base Payouts</th>
+                  <th>ISF</th>
+                  <th>Work Expenses</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr *ngFor="let o of filteredOrders">
+                  <td>{{ o.executionDate | date:'shortDate' }}</td>
+                  <td>{{ o.jobAddress }}</td>
+                  <td>{{ parseDuration(o.orderDuration) | number:'1.2-2' }}</td>
+                  <td>{{ baseRate * parseDuration(o.orderDuration) | currency:'CAD':'symbol':'1.2-2' }}</td>
+                  <td>{{ baseRate * parseDuration(o.orderDuration) * 0.10 | currency:'CAD':'symbol':'1.2-2' }}</td>
+                  <td>{{ 0 | currency:'CAD':'symbol':'1.2-2' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
         </div>
       </ng-container>
     </main>


### PR DESCRIPTION
## Summary
- enhance dashboard UI with a **My Work** section
- show period filters, activity summary and work order log
- compute helper base rate and payouts in component logic
- add styling for new section

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_684bc81bcc808324b08783cf2bdbb527