### PR TITLE
Implement auto-refresh for chat and notifications

### DIFF
--- a/SLFrontend/src/app/notifications/notifications.component.ts
+++ b/SLFrontend/src/app/notifications/notifications.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { NotificationService } from '../services/notification.service';
 import { CommonModule, NgFor, NgIf } from '@angular/common';
 
@@ -9,14 +9,16 @@ import { CommonModule, NgFor, NgIf } from '@angular/common';
   templateUrl: './notifications.component.html',
   styleUrls: ['./notifications.component.css']
 })
-export class NotificationsComponent implements OnInit {
+export class NotificationsComponent implements OnInit, OnDestroy {
   notifications: any[] = [];
   showDropdown = false;  // ✅ Gérer l'affichage du menu
+  private pollInterval: any;
 
   constructor(private notificationService: NotificationService) {}
 
   ngOnInit(): void {
     this.loadNotifications();
+    this.startPolling();
   }
 
   // ✅ Charger les notifications
@@ -30,5 +32,17 @@ export class NotificationsComponent implements OnInit {
   // ✅ Toggle du dropdown
   toggleDropdown(): void {
     this.showDropdown = !this.showDropdown;
+  }
+
+  startPolling() {
+    this.pollInterval = setInterval(() => {
+      this.loadNotifications();
+    }, 5000);
+  }
+
+  ngOnDestroy(): void {
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- poll chat messages and notifications periodically
- clean up intervals when components are destroyed

## Testing
- `npm test --silent` *(fails: ng not found)*
- `python SwiftLink/manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684fd18c7aec8324ae6fcbb88a7307ca