### PR TITLE
Add membership API

### DIFF
--- a/SwiftLink/Client/serializers.py
+++ b/SwiftLink/Client/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import Membership
+
+class MembershipSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Membership
+        fields = '__all__'

--- a/SwiftLink/Client/urls.py
+++ b/SwiftLink/Client/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import get_memberships
+
+urlpatterns = [
+    path('memberships/', get_memberships, name='get_memberships'),
+]

--- a/SwiftLink/Client/views.py
+++ b/SwiftLink/Client/views.py
@@ -1,3 +1,15 @@
 from django.shortcuts import render
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from .models import Membership
+from .serializers import MembershipSerializer
 
 # Create your views here.
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def get_memberships(request):
+    memberships = Membership.objects.all()
+    serializer = MembershipSerializer(memberships, many=True)
+    return Response(serializer.data)

--- a/SwiftLink/SwiftLink/urls.py
+++ b/SwiftLink/SwiftLink/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path('api/', include('Order.urls',)),
     path('api/', include('notification.urls',)),
     path('api/', include('Workforce.urls',)),
+    path('api/', include('Client.urls',)),
     path('api/chat/', include('chat.urls')),
     path('api/', include('invoice.urls')),
 ]


### PR DESCRIPTION
## Summary
- add `MembershipSerializer` for membership model
- expose `get_memberships` view
- create `Client.urls` and wire membership endpoint
- include Client URLs in project router

## Testing
- `python SwiftLink/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_68513a06e0348324b610a0bc698bca08