### PR TITLE
Fix membership field handling in signup

### DIFF
--- a/SwiftLink/Ref_User/serializers.py
+++ b/SwiftLink/Ref_User/serializers.py
@@ -80,10 +80,12 @@ class ClientSerializer(serializers.ModelSerializer):
         # 🔥 Assigner l'entityID du user au client
         validated_data['entityID'] = user.entityId  
 
+        # Retirer la membership avant de créer le client afin d'éviter de
+        # passer ce champ non défini au modèle Client
+        membership_type = validated_data.pop('membershipType', None)
+
         # 🔹 Créer le client en associant l'utilisateur
         client = Client.objects.create(UserId=user, **validated_data)
-
-        membership_type = validated_data.pop('membershipType', None)
         if membership_type:
             try:
                 membership = Membership.objects.get(membershipType=membership_type)


### PR DESCRIPTION
## Summary
- avoid passing `membershipType` to the `Client` model when creating clients

## Testing
- `python SwiftLink/manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_685145b753288324bf718843b1087dee