### PR TITLE
Add invoice status and membership charges

### DIFF
--- a/SLFrontend/src/app/helper-dashboard/invoice/invoice.component.html
+++ b/SLFrontend/src/app/helper-dashboard/invoice/invoice.component.html
@@ -1,10 +1,18 @@
 <div class="invoice-container">
-    <h2>Invoice for {{ invoice?.serviceType}}</h2>
+    <h2>Invoice #{{ invoice?.invoiceID || 'New' }} for {{ invoice?.serviceType}}</h2>
   
     <p>Duration: {{ invoice?.duration }}</p>
     <p>Unit Price: {{ invoice?.unitPrice }} $ CAD </p>
     <p>Base Amount: {{ invoice?.baseAmount | number: '1.2-2' }} $ CAD </p>
   
+    <p>Status:
+        <select [(ngModel)]="invoice.status">
+            <option *ngFor="let s of statuses" [value]="s">{{s}}</option>
+        </select>
+    </p>
+    <p>Description:</p>
+    <textarea [(ngModel)]="invoice.description"></textarea>
+
     <h3>Extras</h3>
     <div *ngFor="let extra of invoice?.extras; let i = index">
       {{ extra.label }} - {{ extra.price }} $ CAD 
@@ -26,4 +34,3 @@
         </span>
       </button>
   </div>
-  

--- a/SLFrontend/src/app/helper-dashboard/invoice/invoice.component.ts
+++ b/SLFrontend/src/app/helper-dashboard/invoice/invoice.component.ts
@@ -16,6 +16,12 @@ export class InvoiceComponent implements OnInit {
   newExtra = { label: '', price: 0 };
   totalAmount: number = 0;
   isSending: boolean = false;
+  statuses = [
+    'paid by E-transfer',
+    'paid by cash',
+    'Future Payment',
+    'In Dispute'
+  ];
 
   constructor(
     private route: ActivatedRoute,

--- a/SwiftLink/invoice/migrations/0002_add_status_description.py
+++ b/SwiftLink/invoice/migrations/0002_add_status_description.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('invoice', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='invoice',
+            name='status',
+            field=models.CharField(choices=[('paid by E-transfer', 'Paid by E-transfer'), ('paid by cash', 'Paid by cash'), ('Future Payment', 'Future Payment'), ('In Dispute', 'In Dispute')], default='Future Payment', max_length=50),
+        ),
+        migrations.AddField(
+            model_name='invoice',
+            name='description',
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/SwiftLink/invoice/models.py
+++ b/SwiftLink/invoice/models.py
@@ -16,6 +16,14 @@ class Invoice(models.Model):
     extras = models.JSONField(default=list, blank=True)  # [{'label': 'Extra cleaning', 'price': 50.00}, ...]
 
     totalAmount = models.DecimalField(max_digits=10, decimal_places=2)
+    class InvoiceStatus(models.TextChoices):
+        PAID_E_TRANSFER = 'paid by E-transfer', 'Paid by E-transfer'
+        PAID_CASH = 'paid by cash', 'Paid by cash'
+        FUTURE_PAYMENT = 'Future Payment', 'Future Payment'
+        IN_DISPUTE = 'In Dispute', 'In Dispute'
+
+    status = models.CharField(max_length=50, choices=InvoiceStatus.choices, default=InvoiceStatus.FUTURE_PAYMENT)
+    description = models.TextField(blank=True, null=True)
     createdAt = models.DateTimeField(auto_now_add=True)
     sentToClient = models.BooleanField(default=False)
 

--- a/SwiftLink/templates/invoice_template.html
+++ b/SwiftLink/templates/invoice_template.html
@@ -18,6 +18,8 @@
     <p>Duration: {{ invoice.duration }}</p>
     <p>Unit Price: {{ invoice.unitPrice }} $ CAD</p>
     <p>Base Amount: {{ invoice.baseAmount }} $ CAD</p>
+    <p>Status: {{ invoice.status }}</p>
+    <p>Description: {{ invoice.description }}</p>
 
     <h3>Extras</h3>
     <table>


### PR DESCRIPTION
## Summary
- add invoice status and description fields
- compute membership fees when initializing an invoice
- allow setting status and description when submitting invoice
- show status and description in generated PDF
- extend helper dashboard invoice component to manage status and show invoice id
- create migration for the new invoice fields

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_68515448b28883249b976dde1d1336e7