### PR TITLE
Add client invoice views

### DIFF
--- a/SLFrontend/src/app/app.routes.ts
+++ b/SLFrontend/src/app/app.routes.ts
@@ -33,6 +33,8 @@ import { AccountsComponent } from './office-dashboard/accounts/accounts.componen
 import { IntakeComponent } from './office-dashboard/intake/intake.component';
 import { WelcomeComponent } from './office-dashboard/welcome/welcome.component';
 import { SigninclientComponent } from './auth/signinclient/signinclient.component';
+import { ClientInvoicesComponent } from './client-invoices/client-invoices.component';
+import { InvoiceDetailComponent } from './invoice-detail/invoice-detail.component';
 
 export const routes: Routes = [
     { path: '', component: HomeComponent },
@@ -68,9 +70,11 @@ export const routes: Routes = [
       { path: 'my-work', component: DashboardComponent },
       { path: 'work-board', component: OrdersComponent },
       { path: 'invoice/:orderId', component: InvoiceComponent },
-      
+
     ]
   },
+  { path: 'invoices', component: ClientInvoicesComponent },
+  { path: 'invoices/:id', component: InvoiceDetailComponent },
   { path: 'office-dashboard',
         component: OfficeDashboardComponent,
         canActivate: [authGuard],

--- a/SLFrontend/src/app/client-invoices/client-invoices.component.css
+++ b/SLFrontend/src/app/client-invoices/client-invoices.component.css
@@ -1,0 +1,16 @@
+.invoice-list {
+  max-width: 600px;
+  margin: 20px auto;
+}
+.invoice-list ul {
+  list-style: none;
+  padding: 0;
+}
+.invoice-list li {
+  padding: 10px;
+  border-bottom: 1px solid #ccc;
+  cursor: pointer;
+}
+.invoice-list li:hover {
+  background-color: #f0f0f0;
+}

--- a/SLFrontend/src/app/client-invoices/client-invoices.component.html
+++ b/SLFrontend/src/app/client-invoices/client-invoices.component.html
@@ -1,0 +1,8 @@
+<div class="invoice-list">
+  <h2>Your Invoices</h2>
+  <ul>
+    <li *ngFor="let inv of invoices" (click)="viewInvoice(inv.invoiceID)">
+      Invoice #{{ inv.invoiceID }} - {{ inv.serviceType }}
+    </li>
+  </ul>
+</div>

--- a/SLFrontend/src/app/client-invoices/client-invoices.component.ts
+++ b/SLFrontend/src/app/client-invoices/client-invoices.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { CommonModule, NgFor } from '@angular/common';
+import { InvoiceService } from '../services/invoice.service';
+
+@Component({
+  selector: 'app-client-invoices',
+  standalone: true,
+  imports: [CommonModule, NgFor],
+  templateUrl: './client-invoices.component.html',
+  styleUrl: './client-invoices.component.css'
+})
+export class ClientInvoicesComponent implements OnInit {
+  invoices: any[] = [];
+
+  constructor(private invoiceService: InvoiceService, private router: Router) {}
+
+  ngOnInit() {
+    this.invoiceService.getClientInvoices().subscribe(data => {
+      this.invoices = data;
+    });
+  }
+
+  viewInvoice(id: number) {
+    this.router.navigate(['/invoices', id]);
+  }
+}

--- a/SLFrontend/src/app/home/navbar/navbar.component.html
+++ b/SLFrontend/src/app/home/navbar/navbar.component.html
@@ -15,6 +15,7 @@
     </ng-container>
 
     <ng-container *ngIf="isClientLoggedIn">
+      <li *ngIf="currentUser?.role === 'Client'"><a routerLink="/invoices">Invoices</a></li>
       <li>
         <button (click)="onLogout()" class="logout-button">Logout</button>
       </li>

--- a/SLFrontend/src/app/invoice-detail/invoice-detail.component.css
+++ b/SLFrontend/src/app/invoice-detail/invoice-detail.component.css
@@ -1,0 +1,10 @@
+.invoice-detail {
+  max-width: 800px;
+  margin: 30px auto;
+}
+.payment-box {
+  margin-top: 20px;
+  padding: 15px;
+  border: 1px solid #ccc;
+  background-color: #f9f9f9;
+}

--- a/SLFrontend/src/app/invoice-detail/invoice-detail.component.html
+++ b/SLFrontend/src/app/invoice-detail/invoice-detail.component.html
@@ -1,0 +1,22 @@
+<div *ngIf="invoice" class="invoice-detail">
+  <h2>Invoice #{{ invoice.invoiceID }}</h2>
+  <p>Status: {{ invoice.status }}</p>
+  <p>Service: {{ invoice.serviceType }}</p>
+  <p>Duration: {{ invoice.duration }}</p>
+  <p>Unit Price: {{ invoice.unitPrice }} $ CAD</p>
+  <p>Base Amount: {{ invoice.baseAmount }} $ CAD</p>
+
+  <div *ngIf="invoice.extras && invoice.extras.length">
+    <h3>Extras</h3>
+    <ul>
+      <li *ngFor="let extra of invoice.extras">{{ extra.label }} - {{ extra.price }} $ CAD</li>
+    </ul>
+  </div>
+
+  <p>Total: {{ invoice.totalAmount }} $ CAD</p>
+
+  <div class="payment-box">
+    please send an Interac e-Transfer to {{ invoice.helper_professional_email }}.<br />
+    Include the invoice number in the e-Transfer message.
+  </div>
+</div>

--- a/SLFrontend/src/app/invoice-detail/invoice-detail.component.ts
+++ b/SLFrontend/src/app/invoice-detail/invoice-detail.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { CommonModule, NgFor } from '@angular/common';
+import { InvoiceService } from '../services/invoice.service';
+
+@Component({
+  selector: 'app-invoice-detail',
+  standalone: true,
+  imports: [CommonModule, NgFor],
+  templateUrl: './invoice-detail.component.html',
+  styleUrl: './invoice-detail.component.css'
+})
+export class InvoiceDetailComponent implements OnInit {
+  invoice: any;
+
+  constructor(private route: ActivatedRoute, private invoiceService: InvoiceService) {}
+
+  ngOnInit() {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.invoiceService.getInvoice(+id).subscribe(data => this.invoice = data);
+    }
+  }
+}

--- a/SLFrontend/src/app/services/invoice.service.ts
+++ b/SLFrontend/src/app/services/invoice.service.ts
@@ -20,4 +20,12 @@ export class InvoiceService {
   submitInvoice(orderId: string, data: any) {
     return this.http.post(`${this.apiUrl}${orderId}/submit/`, data, { responseType: 'blob' });
   }
+
+  getClientInvoices(): Observable<any[]> {
+    return this.http.get<any[]>(`${this.apiUrl}client/`);
+  }
+
+  getInvoice(id: number): Observable<any> {
+    return this.http.get<any>(`${this.apiUrl}${id}/`);
+  }
 }

--- a/SwiftLink/invoice/serializers.py
+++ b/SwiftLink/invoice/serializers.py
@@ -1,7 +1,15 @@
 from rest_framework import serializers
 from .models import Invoice
 
+
 class InvoiceSerializer(serializers.ModelSerializer):
+    helper_professional_email = serializers.SerializerMethodField()
+
     class Meta:
         model = Invoice
         fields = '__all__'
+
+    def get_helper_professional_email(self, obj):
+        if obj.helper:
+            return obj.helper.professionnelemail
+        return None

--- a/SwiftLink/invoice/urls.py
+++ b/SwiftLink/invoice/urls.py
@@ -3,5 +3,7 @@ from . import views
 urlpatterns = [
     path('invoices/<order_id>/init/',views.init_invoice ),
     path('invoices/<order_id>/submit/',views.submit_invoice ),
-    
+    path('invoices/client/', views.client_invoices),
+    path('invoices/<int:invoice_id>/', views.invoice_detail),
+
 ]


### PR DESCRIPTION
## Summary
- allow clients to list and view invoices
- expose invoice APIs for clients
- display invoices link in navbar for clients only

## Testing
- `pytest -q`
- `npm test --prefix SLFrontend`

------
https://chatgpt.com/codex/tasks/task_b_685157c7df288324b5b3bcbdd53bc4ab