### PR TITLE
Add helper invoices dashboard

### DIFF
--- a/SLFrontend/src/app/app.routes.ts
+++ b/SLFrontend/src/app/app.routes.ts
@@ -15,6 +15,8 @@ import { AgendaComponent } from './helper-dashboard/agenda/agenda.component';
 import { DashboardComponent } from './helper-dashboard/dashboard/dashboard.component';
 import { OrdersComponent } from './helper-dashboard/orders/orders.component';
 import { InvoiceComponent } from './helper-dashboard/invoice/invoice.component';
+import { InvoicesComponent } from './helper-dashboard/invoices/invoices.component';
+import { InvoiceDetailsComponent } from './helper-dashboard/invoice-details/invoice-details.component';
 import { AdminDashboardComponent } from './admin-dashboard/admin-dashboard.component';
 import { AdminHelperViewComponent } from './admin-helper-view/admin-helper-view.component';
 import { HelperFormComponent } from './helper-form/helper-form.component';
@@ -70,6 +72,8 @@ export const routes: Routes = [
       { path: 'my-work', component: DashboardComponent },
       { path: 'work-board', component: OrdersComponent },
       { path: 'invoice/:orderId', component: InvoiceComponent },
+      { path: 'invoices', component: InvoicesComponent },
+      { path: 'invoices/:id', component: InvoiceDetailsComponent },
 
     ]
   },

--- a/SLFrontend/src/app/helper-dashboard/invoice-details/invoice-details.component.css
+++ b/SLFrontend/src/app/helper-dashboard/invoice-details/invoice-details.component.css
@@ -1,0 +1,11 @@
+.invoice-detail {
+  padding: 1rem;
+}
+.payment-box {
+  margin-top: 1rem;
+  font-weight: bold;
+}
+.note-box {
+  margin-top: 0.5rem;
+  font-style: italic;
+}

--- a/SLFrontend/src/app/helper-dashboard/invoice-details/invoice-details.component.html
+++ b/SLFrontend/src/app/helper-dashboard/invoice-details/invoice-details.component.html
@@ -1,0 +1,14 @@
+<div *ngIf="invoice && (invoice.status === 'paid by E-transfer' || invoice.status === 'paid by cash')" class="invoice-detail">
+  <h2>Invoice #{{ invoice.invoiceID }}</h2>
+  <p>ISF contribution (10%): {{ isf | number:'1.2-2' }} $ CAD</p>
+  <p>Platform fee (10%): {{ platformFee | number:'1.2-2' }} $ CAD</p>
+  <p *ngIf="payPerUse">Pay-per-use fee: {{ payPerUse }} $ CAD</p>
+  <p>Total due: {{ totalDue | number:'1.2-2' }} $ CAD</p>
+  <div class="payment-box">
+    send e-Transfer to : platform.fee@swift-link.ca<br />
+    include invoice # in the message
+  </div>
+  <div class="note-box">
+    the 10% ISF and 10% Platform fee are not deducted from your rate. They are paid on top by the client .
+  </div>
+</div>

--- a/SLFrontend/src/app/helper-dashboard/invoice-details/invoice-details.component.ts
+++ b/SLFrontend/src/app/helper-dashboard/invoice-details/invoice-details.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { CommonModule, NgFor } from '@angular/common';
+import { InvoiceService } from '../../services/invoice.service';
+
+@Component({
+  selector: 'app-helper-invoice-detail',
+  standalone: true,
+  imports: [CommonModule, NgFor],
+  templateUrl: './invoice-details.component.html',
+  styleUrl: './invoice-details.component.css'
+})
+export class InvoiceDetailsComponent implements OnInit {
+  invoice: any;
+  isf = 0;
+  platformFee = 0;
+  payPerUse = 0;
+  totalDue = 0;
+
+  constructor(private route: ActivatedRoute, private invoiceService: InvoiceService) {}
+
+  ngOnInit() {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.invoiceService.getInvoice(+id).subscribe(data => {
+        this.invoice = data;
+        this.calculateFees();
+      });
+    }
+  }
+
+  calculateFees() {
+    const amount = parseFloat(this.invoice.totalAmount);
+    this.isf = amount * 0.10;
+    this.platformFee = amount * 0.10;
+    const ppu = this.invoice.extras?.find((e: any) => e.label === 'Pay-per-use Fee');
+    this.payPerUse = ppu ? parseFloat(ppu.price) : 0;
+    this.totalDue = amount + this.isf + this.platformFee;
+  }
+}

--- a/SLFrontend/src/app/helper-dashboard/invoices/invoices.component.css
+++ b/SLFrontend/src/app/helper-dashboard/invoices/invoices.component.css
@@ -1,0 +1,14 @@
+.invoice-list ul {
+  list-style: none;
+  padding: 0;
+}
+.invoice-list li {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.invoice-list span {
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/SLFrontend/src/app/helper-dashboard/invoices/invoices.component.html
+++ b/SLFrontend/src/app/helper-dashboard/invoices/invoices.component.html
@@ -1,0 +1,11 @@
+<div class="invoice-list">
+  <h2>Your Invoices</h2>
+  <ul>
+    <li *ngFor="let inv of invoices">
+      <span (click)="viewInvoice(inv)">Invoice #{{ inv.invoiceID }} - {{ inv.serviceType }}</span>
+      <select [(ngModel)]="inv.status" (change)="updateStatus(inv)">
+        <option *ngFor="let s of statuses" [value]="s">{{ s }}</option>
+      </select>
+    </li>
+  </ul>
+</div>

--- a/SLFrontend/src/app/helper-dashboard/invoices/invoices.component.ts
+++ b/SLFrontend/src/app/helper-dashboard/invoices/invoices.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { CommonModule, NgFor } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { InvoiceService } from '../../services/invoice.service';
+
+@Component({
+  selector: 'app-helper-invoices',
+  standalone: true,
+  imports: [CommonModule, NgFor, FormsModule],
+  templateUrl: './invoices.component.html',
+  styleUrl: './invoices.component.css'
+})
+export class InvoicesComponent implements OnInit {
+  invoices: any[] = [];
+  statuses = [
+    'paid by E-transfer',
+    'paid by cash',
+    'Future Payment',
+    'In Dispute'
+  ];
+
+  constructor(private invoiceService: InvoiceService, private router: Router) {}
+
+  ngOnInit() {
+    this.invoiceService.getHelperInvoices().subscribe(data => {
+      this.invoices = data;
+    });
+  }
+
+  updateStatus(inv: any) {
+    this.invoiceService.updateInvoiceStatus(inv.invoiceID, inv.status).subscribe();
+  }
+
+  viewInvoice(inv: any) {
+    this.router.navigate(['/helper-dashboard/invoices', inv.invoiceID]);
+  }
+}

--- a/SLFrontend/src/app/services/invoice.service.ts
+++ b/SLFrontend/src/app/services/invoice.service.ts
@@ -25,6 +25,14 @@ export class InvoiceService {
     return this.http.get<any[]>(`${this.apiUrl}client/`);
   }
 
+  getHelperInvoices(): Observable<any[]> {
+    return this.http.get<any[]>(`${this.apiUrl}helper/`);
+  }
+
+  updateInvoiceStatus(id: number, status: string) {
+    return this.http.patch(`${this.apiUrl}${id}/status/`, { status });
+  }
+
   getInvoice(id: number): Observable<any> {
     return this.http.get<any>(`${this.apiUrl}${id}/`);
   }

--- a/SLFrontend/src/main.ts
+++ b/SLFrontend/src/main.ts
@@ -21,6 +21,8 @@ import { withInterceptorsFromDi } from '@angular/common/http';
 import { AuthInterceptor } from './auth.interceptor';
 import { ChatComponent } from './app/chat/chat.component';
 import { InvoiceComponent } from './app/helper-dashboard/invoice/invoice.component';
+import { InvoicesComponent } from './app/helper-dashboard/invoices/invoices.component';
+import { InvoiceDetailsComponent } from './app/helper-dashboard/invoice-details/invoice-details.component';
 import { UserProfileComponent } from './app/user-profile/user-profile.component';
 import { HelperProfileComponent } from './app/helper-profile/helper-profile.component';
 import { AdminDashboardComponent } from './app/admin-dashboard/admin-dashboard.component';
@@ -65,7 +67,9 @@ const routes: Routes = [
         { path: 'my-work', component: DashboardComponent },
         { path: 'work-board', component: OrdersComponent },
         { path: 'invoice/:orderId', component: InvoiceComponent },
-        
+        { path: 'invoices', component: InvoicesComponent },
+        { path: 'invoices/:id', component: InvoiceDetailsComponent },
+
       ]
     },
     { path: 'office-dashboard',

--- a/SwiftLink/invoice/urls.py
+++ b/SwiftLink/invoice/urls.py
@@ -4,6 +4,8 @@ urlpatterns = [
     path('invoices/<order_id>/init/',views.init_invoice ),
     path('invoices/<order_id>/submit/',views.submit_invoice ),
     path('invoices/client/', views.client_invoices),
+    path('invoices/helper/', views.helper_invoices),
     path('invoices/<int:invoice_id>/', views.invoice_detail),
+    path('invoices/<int:invoice_id>/status/', views.update_invoice_status),
 
 ]


### PR DESCRIPTION
## Summary
- add invoice listing page for helpers with ability to update status
- show invoice payment details for paid invoices
- expose helper invoice APIs on the backend

## Testing
- `npm test` *(fails: ng not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_685186129d3883248cf7f862b6b9999e