### PR TITLE
Fix GPT endpoint error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# swiftlink
+# SwiftLink
+
+## Environment variables
+
+The application requires an OpenAI API key for the chat functionality.
+Set `OPENAI_API_KEY` in your environment before starting the backend:
+
+```bash
+export OPENAI_API_KEY=<your-key>
+```
+
+If the key is missing the `/api/chat/gpt/` endpoint will return an error.

--- a/SwiftLink/chat/views.py
+++ b/SwiftLink/chat/views.py
@@ -134,6 +134,9 @@ def gpt_message(request):
         role = 'assistant' if msg.sender != request.user else 'user'
         chat_history.append({'role': role, 'content': msg.content})
 
+    if not settings.OPENAI_API_KEY:
+        return Response({'error': 'OpenAI API key not configured'}, status=500)
+
     try:
         client = openai.OpenAI(api_key=settings.OPENAI_API_KEY)
         completion = client.chat.completions.create(model='gpt-4o', messages=chat_history)


### PR DESCRIPTION
## Summary
- document requirement for OPENAI_API_KEY
- return clearer message if the GPT endpoint is missing the API key

## Testing
- `python SwiftLink/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_6852c6ce90508324970f7ca8ae1bd8c2