### PR TITLE
Fix JSON parser error when GPT reply is invalid

### DIFF
--- a/SwiftLink/chat/views.py
+++ b/SwiftLink/chat/views.py
@@ -118,7 +118,7 @@ def extract_json(text: str):
     end = text.rfind("}")
     if start != -1 and end != -1 and end > start:
         return json.loads(text[start:end + 1])
-    raise
+    raise ValueError("No JSON object found in assistant reply")
 
 
 @api_view(['POST'])


### PR DESCRIPTION
## Summary
- improve error handling in `extract_json`

## Testing
- `python SwiftLink/manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_6852f8a517a0832480be2c18a0c670c8