### PR TITLE
Improve navbar notification refresh

### DIFF
--- a/SLFrontend/src/app/home/navbar/navbar.component.html
+++ b/SLFrontend/src/app/home/navbar/navbar.component.html
@@ -26,7 +26,7 @@
           <div *ngIf="conversations.length === 0">No messages</div>
           <ul *ngIf="conversations.length > 0">
             <li *ngFor="let conv of conversations" (click)="openChat(conv.id, conv.helper, conv.order)">
-              Conversation with {{ getOtherUserName(conv) }}
+              You have a discussion with {{ getOtherUserName(conv) }}
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- poll for unread notifications and conversations
- show updated message label
- fix other user display logic

## Testing
- `npm test --silent --no-watch` *(fails: ng not found)*
- `python SwiftLink/manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_b_6853fbd6aca08324ac057c80ad5aee43