### PR TITLE
Fix work orders for missing helper data

### DIFF
--- a/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.html
+++ b/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.html
@@ -106,15 +106,15 @@
     <tr *ngFor="let o of filteredOrders">
       <td>{{ o.order.executionDate | date:'shortDate' }}</td>
       <td>{{ o.order.orderID }}</td>
-      <td>{{ o.workforce.firstName }} {{ o.workforce.lastName }}</td>
-      <td>{{ o.client.firstName }} {{ o.client.lastName }}</td>
-      <td>{{ o.client.address }}</td>
+      <td>{{ o.workforce?.firstName || 'N/A' }} {{ o.workforce?.lastName || '' }}</td>
+      <td>{{ o.client?.firstName || 'N/A' }} {{ o.client?.lastName || '' }}</td>
+      <td>{{ o.client?.address || 'N/A' }}</td>
       <td>{{ o.order.jobTitle }}</td>
       <td>{{ o.order.finalWorkDescription }}</td>
       <td>{{ o.order.contractorNotes }}</td>
       <td>{{ o.order.clientNotes }}</td>
       <td>{{ o.order.orderDuration }}</td>
-      <td>{{ o.workforce.hourlyRatebyService | currency:'USD':'symbol':'1.2-2' }}</td>
+      <td>{{ (o.workforce?.hourlyRatebyService || 0) | currency:'USD':'symbol':'1.2-2' }}</td>
       <td>{{ extrasTotal(o.invoice?.extras) | currency:'USD':'symbol':'1.2-2' }}</td>
       <td>{{ invoicedAmount(o) | currency:'USD':'symbol':'1.2-2' }}</td>
       <td>{{ (invoicedAmount(o) * 0.10) | currency:'USD':'symbol':'1.2-2' }}</td>

--- a/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.ts
+++ b/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.ts
@@ -13,9 +13,9 @@ interface WorkOrderRecord {
     finalWorkDescription?: string;
     contractorNotes?: string;
   };
-  workforce: Workforce;
-  client: Client;
-  invoice: Invoice;
+  workforce: Workforce | null;
+  client: Client | null;
+  invoice: Invoice | null;
 }
 
 @Component({
@@ -69,7 +69,7 @@ export class WorkOrdersComponent implements OnInit {
   applyFilters(): void {
     const todayStr = new Date().toDateString();
     this.filteredOrders = this.workOrders.filter(o => {
-      const contractorName = o.workforce.lastName;
+      const contractorName = o.workforce?.lastName || '';
       const orderDate = new Date(o.order.executionDate || o.order.creationDate);
       const matchContractor = this.selectedContractor ? contractorName === this.selectedContractor.lastName : true;
       const matchDate = this.dateFilter === 'all'
@@ -142,7 +142,7 @@ export class WorkOrdersComponent implements OnInit {
 
   invoicedAmount(record: WorkOrderRecord): number {
     const hours = Number(record.order.orderDuration) || 0;
-    const rate = record.workforce.hourlyRatebyService || 0;
+    const rate = record.workforce?.hourlyRatebyService || 0;
     return hours * rate;
   }
 }


### PR DESCRIPTION
## Summary
- handle null workforce, client and invoice objects in work orders component
- show fallback information when helper or client data is missing

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_685574a6d65883248e8780f81e8faaae