### PR TITLE
Add invoice status to helper dashboard

### DIFF
--- a/SLFrontend/src/app/helper-dashboard/dashboard/dashboard.component.css
+++ b/SLFrontend/src/app/helper-dashboard/dashboard/dashboard.component.css
@@ -214,29 +214,38 @@
   width: 100%;
   border-collapse: collapse;
   margin-top: 1rem;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.orders-log thead {
+  background-color: #002f5f;
+  color: white;
 }
 
 .orders-log th,
 .orders-log td {
-  border: 1px solid #ddd;
-  padding: 0.75rem;
+  padding: 0.75rem 0.5rem;
+  font-size: 0.85rem;
   text-align: left;
-  font-size: 0.95rem;
-}
-
-.orders-log th {
-  background-color: #f0f4f8;
-  color: #333;
-  font-weight: 600;
-}
-
-.orders-log tr:nth-child(even) {
-  background-color: #fafafa;
+  border-bottom: 1px solid #e0e0e0;
 }
 
 .orders-log tr:hover {
   background-color: #f1f7ff;
-  transition: background-color 0.3s ease;
+}
+
+.orders-log th {
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .orders-log th,
+  .orders-log td {
+    font-size: 0.72rem;
+    padding: 0.5rem;
+  }
 }
 
 

--- a/SLFrontend/src/app/helper-dashboard/dashboard/dashboard.component.html
+++ b/SLFrontend/src/app/helper-dashboard/dashboard/dashboard.component.html
@@ -57,6 +57,7 @@
         <th>Base Payouts</th>
         <th>ISF <small>(Applied on base rate only)</small></th>
         <th>Work Expenses</th>
+        <th>Invoice Status</th>
       </tr>
     </thead>
     <tbody>
@@ -67,6 +68,7 @@
         <td>{{ baseRate * parseDuration(o.orderDuration) | currency:'CAD':'symbol':'1.2-2' }}</td>
         <td>{{ baseRate * parseDuration(o.orderDuration) * 0.10 | currency:'CAD':'symbol':'1.2-2' }}</td>
         <td>{{ 0 | currency:'CAD':'symbol':'1.2-2' }}</td>
+        <td>{{ invoiceStatusMap[o.orderID] || 'N/A' }}</td>
       </tr>
     </tbody>
   </table>

--- a/SLFrontend/src/app/helper-dashboard/dashboard/dashboard.component.ts
+++ b/SLFrontend/src/app/helper-dashboard/dashboard/dashboard.component.ts
@@ -10,6 +10,7 @@ import { FormsModule } from '@angular/forms';
 import { OrderService } from '../../services/order.service';
 import { AuthService } from '../../services/auth.service';
 import { DashboardService } from '../../services/dashboard.service';
+import { InvoiceService } from '../../services/invoice.service';
 
 import { DashboardStats, Job, DashboardResponse } from '../../models/dashboard.model';
 
@@ -40,6 +41,7 @@ export class DashboardComponent implements OnInit, AfterViewInit {
   errorMessage = '';
   helperServiceTypes: string[] = [];
   orders: any[] = [];
+  invoiceStatusMap: { [orderId: number]: string } = {};
   monthlyIncomeMap: { [key: string]: number } = {};
   chartInstance: Chart | null = null;
   baseRate = 0;
@@ -59,6 +61,7 @@ export class DashboardComponent implements OnInit, AfterViewInit {
     private orderService: OrderService,
     private authService: AuthService,
     private dashboardService: DashboardService,
+    private invoiceService: InvoiceService,
     private router: Router
   ) {
     Chart.register(...registerables);
@@ -124,7 +127,18 @@ export class DashboardComponent implements OnInit, AfterViewInit {
     this.orderService.getAllOrders().subscribe({
       next: (data) => {
         this.orders = data;
-        this.calculateSummary();
+        this.invoiceService.getHelperInvoices().subscribe({
+          next: (invoices) => {
+            this.invoiceStatusMap = {};
+            invoices.forEach((inv: any) => {
+              this.invoiceStatusMap[inv.orderID] = inv.status;
+            });
+            this.calculateSummary();
+          },
+          error: () => {
+            this.calculateSummary();
+          }
+        });
       },
       error: (err) => {
         console.error('Error loading orders:', err);


### PR DESCRIPTION
## Summary
- display invoice status in the helper **My Work** table
- fetch helper invoices on dashboard load
- restyle table to match office work orders

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_6855828c3a18832484aa763be1503809