### PR TITLE
Implement promo code sign-in redirect

### DIFF
--- a/SLFrontend/src/app/auth/signin/signin.component.html
+++ b/SLFrontend/src/app/auth/signin/signin.component.html
@@ -3,7 +3,7 @@
     <h1>Welcome To Swift Helpers</h1>
 
     <div class="auth-buttons">
-      <button class="btn-secondary" [routerLink]="['/signin-client']">Sign In</button>
+      <button class="btn-secondary" (click)="onSignIn()">Sign In</button>
       <button class="btn-primary" (click)="redirectSignup()">Sign Up</button>
     </div>
 

--- a/SLFrontend/src/app/auth/signin/signin.component.ts
+++ b/SLFrontend/src/app/auth/signin/signin.component.ts
@@ -19,7 +19,6 @@ export class SigninComponent implements OnInit {
   memberships: Membership[] = [];
   selectedMembership = '';
   promotionCode = '';
-
   constructor(
     private fb: FormBuilder,
     private authService: AuthService,
@@ -68,6 +67,15 @@ export class SigninComponent implements OnInit {
     this.router.navigate(['/signup'], {
       queryParams: { membership: this.selectedMembership }
     });
+  }
+
+  onSignIn() {
+    const code = this.promotionCode.trim().toLowerCase();
+    const valid = this.memberships.some(m =>
+      m.promotionCode && m.promotionCode.trim().toLowerCase() === code
+    );
+    const queryParams = valid ? { promo: 'true' } : {};
+    this.router.navigate(['/signin-client'], { queryParams });
   }
 
 }

--- a/SLFrontend/src/app/auth/signinclient/signinclient.component.css
+++ b/SLFrontend/src/app/auth/signinclient/signinclient.component.css
@@ -81,3 +81,12 @@ input:focus {
 .switch-auth a:hover {
   text-decoration: underline;
 }
+
+.promo-banner {
+  background-color: #e0f7fa;
+  color: #006064;
+  padding: 10px;
+  text-align: center;
+  margin-bottom: 1rem;
+  border-radius: 6px;
+}

--- a/SLFrontend/src/app/auth/signinclient/signinclient.component.html
+++ b/SLFrontend/src/app/auth/signinclient/signinclient.component.html
@@ -1,15 +1,16 @@
- <form (ngSubmit)="login()" [formGroup]="form">
-    <input type="email" formControlName="email" placeholder="Email" />
-    <input type="password" formControlName="password" placeholder="Password" />
-    <button type="submit" class="signin-button">Sign In</button>
+<div *ngIf="promoMessage" class="promo-banner">{{ promoMessage }}</div>
+<form (ngSubmit)="login()" [formGroup]="form">
+  <input type="email" formControlName="email" placeholder="Email" />
+  <input type="password" formControlName="password" placeholder="Password" />
+  <button type="submit" class="signin-button">Sign In</button>
 
-    <div *ngIf="errorMessage" class="error-message">
-      {{ errorMessage }}
-    </div>
-<div class="forgot-link">
-  <a routerLink="/forgot-password">Forgot your password?</a>
-</div>
-    <div class="switch-auth">
-      Don't have an account? <a (click)="redirectSignup()">Create an account</a>
-    </div>
-  </form>
+  <div *ngIf="errorMessage" class="error-message">
+    {{ errorMessage }}
+  </div>
+  <div class="forgot-link">
+    <a routerLink="/forgot-password">Forgot your password?</a>
+  </div>
+  <div class="switch-auth">
+    Don't have an account? <a (click)="redirectSignup()">Create an account</a>
+  </div>
+</form>

--- a/SLFrontend/src/app/auth/signinclient/signinclient.component.ts
+++ b/SLFrontend/src/app/auth/signinclient/signinclient.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule, NgFor } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
-import { Router, RouterModule } from '@angular/router';
+import { Router, RouterModule, ActivatedRoute } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 
 @Component({
@@ -11,14 +11,16 @@ import { AuthService } from '../../services/auth.service';
   templateUrl: './signinclient.component.html',
   styleUrl: './signinclient.component.css'
 })
-export class SigninclientComponent {
+export class SigninclientComponent implements OnInit {
     form: FormGroup;
     errorMessage = '';
+    promoMessage = '';
   constructor(
       private fb: FormBuilder,
       private authService: AuthService,
       private router: Router,
-      
+      private route: ActivatedRoute,
+
     ) {
       // Création du formulaire avec validation
       this.form = this.fb.group({
@@ -26,6 +28,13 @@ export class SigninclientComponent {
         password: ['', Validators.required],
       });
     }
+
+  ngOnInit(): void {
+    const promo = this.route.snapshot.queryParamMap.get('promo');
+    if (promo === 'true') {
+      this.promoMessage = 'Sign in with promotion code 1 free month';
+    }
+  }
 login() {
   if (this.form.invalid) {
     return;


### PR DESCRIPTION
## Summary
- add sign-in redirect logic in signin component
- show promo banner on the client signin page when code is valid
- ensure promo code validation ignores case

## Testing
- `npm test` *(fails: ng not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_685ac413bd6c83248a454800e743b777