### PR TITLE
Show selected contractor rate in work orders

### DIFF
--- a/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.html
+++ b/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.html
@@ -56,6 +56,10 @@
     <h4>Confirmed Hours</h4>
     <p class="value">{{activitySummary.confirmedHours}}</p>
   </div>
+  <div class="summary-card" *ngIf="selectedContractor">
+    <h4>Hourly Base Rate</h4>
+    <p class="value">{{activitySummary.hourlyBaseRate | currency:'USD':'symbol':'1.2-2'}}</p>
+  </div>
 </div>
 
 <div class="summary-grid">

--- a/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.ts
+++ b/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.ts
@@ -38,7 +38,7 @@ export class WorkOrdersComponent implements OnInit {
   selectedContractor: Workforce | null = null;
 
   rateSummary = { median: 0, average: 0, max: 0, min: 0 };
-  activitySummary = { total: 0, scheduled: 0, canceled: 0, confirmedHours: 0 };
+  activitySummary = { total: 0, scheduled: 0, canceled: 0, confirmedHours: 0, hourlyBaseRate: 0 };
   salesSummary = { totalSales: 0, collectedIsf: 0, pendingPayments: 0, pendingIsf: 0 };
 
   constructor(private orderService: OrderService,private adminService: AdminService) {}
@@ -117,6 +117,9 @@ export class WorkOrdersComponent implements OnInit {
       this.activitySummary.confirmedHours = completed.reduce(
         (sum, o) => sum + (Number(o.order.orderDuration) || 0), 0
       );
+      this.activitySummary.hourlyBaseRate = this.selectedContractor
+        ? Number(this.selectedContractor.hourlyRatebyService || 0)
+        : 0;
 
       // Sales summary
       const totalSales = this.filteredOrders.reduce(


### PR DESCRIPTION
## Summary
- extend work order dashboard summary to show contractor's hourly rate
- show selected contractor rate in activity summary card

## Testing
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b064683ac8324b792b2055d2a66de