### PR TITLE
Add office dashboard login for super admin

### DIFF
--- a/SLFrontend/src/app/auth/signin/signin.component.ts
+++ b/SLFrontend/src/app/auth/signin/signin.component.ts
@@ -55,7 +55,9 @@ export class SigninComponent implements OnInit {
       if (role === 'Client') {
         this.router.navigate(['/']);
       } else if (role === 'Super Admin') {
-        this.router.navigate(['/office-dashboard']);
+        // Super admin should login directly via /office-dashboard
+        this.authService.logout();
+        this.errorMessage = 'Please access the office dashboard to sign in.';
       }
     },
     error: (err) => {

--- a/SLFrontend/src/app/office-dashboard/office-dashboard.component.css
+++ b/SLFrontend/src/app/office-dashboard/office-dashboard.component.css
@@ -140,7 +140,7 @@
     margin-top: 1rem;
     color: #002f5f;
   }
-.welcome-message {
+  .welcome-message {
   text-align: center;
   margin-top: 80px;
   font-size: 1.8rem;
@@ -154,6 +154,58 @@
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
+}
+
+.login-container form {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  max-width: 400px;
+  margin: auto;
+}
+
+.login-container input[type="email"],
+.login-container input[type="password"] {
+  width: 100%;
+  padding: 12px;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  transition: border-color 0.3s ease;
+}
+
+.login-container input:focus {
+  border-color: #0078d4;
+  outline: none;
+}
+
+.signin-button {
+  width: 100%;
+  background-color: #002f5f;
+  color: #fff;
+  padding: 12px;
+  font-size: 1rem;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  margin-bottom: 1rem;
+}
+
+.signin-button:hover {
+  background-color: #004080;
+}
+
+.error-message {
+  color: #d32f2f;
+  background-color: #fdecea;
+  padding: 10px;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  text-align: center;
+  margin-bottom: 1rem;
 }
 
 }

--- a/SLFrontend/src/app/office-dashboard/office-dashboard.component.html
+++ b/SLFrontend/src/app/office-dashboard/office-dashboard.component.html
@@ -1,10 +1,15 @@
-<div class="dashboard-container">
-  <!-- Sidebar (toujours présente) -->
-  <app-sidebar class="sidebar"></app-sidebar>
+<div *ngIf="!isLoggedIn" class="login-container">
+  <form (ngSubmit)="login()" [formGroup]="form">
+    <input type="email" formControlName="email" placeholder="Email" />
+    <input type="password" formControlName="password" placeholder="Password" />
+    <button type="submit" class="signin-button">Sign In</button>
+    <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
+  </form>
+</div>
 
-  <!-- Contenu Principal (change selon la route) -->
+<div *ngIf="isLoggedIn" class="dashboard-container">
+  <app-sidebar class="sidebar"></app-sidebar>
   <main class="main-content">
-    
-    <router-outlet> </router-outlet>
+    <router-outlet></router-outlet>
   </main>
 </div>

--- a/SLFrontend/src/app/office-dashboard/office-dashboard.component.ts
+++ b/SLFrontend/src/app/office-dashboard/office-dashboard.component.ts
@@ -1,22 +1,69 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { SidebarComponent } from './sidebar/sidebar.component';
 import { NgChartsModule } from 'ng2-charts';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatIconModule } from '@angular/material/icon';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, RouterModule } from '@angular/router';
+import { FormBuilder, FormGroup, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { AuthService } from '../services/auth.service';
 
 @Component({
   selector: 'app-office-dashboard',
   standalone: true,
-  imports: [    CommonModule,SidebarComponent,
-      NgChartsModule,
-      MatProgressSpinnerModule,
-      MatIconModule,
-      RouterOutlet],
+  imports: [
+    CommonModule,
+    SidebarComponent,
+    NgChartsModule,
+    MatProgressSpinnerModule,
+    MatIconModule,
+    RouterOutlet,
+    RouterModule,
+    FormsModule,
+    ReactiveFormsModule
+  ],
   templateUrl: './office-dashboard.component.html',
   styleUrl: './office-dashboard.component.css'
 })
-export class OfficeDashboardComponent {
+export class OfficeDashboardComponent implements OnInit {
+  form: FormGroup;
+  errorMessage = '';
+  isLoggedIn = false;
 
+  constructor(private fb: FormBuilder, private authService: AuthService) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.authService.getCurrentUser().subscribe({
+      next: user => {
+        if (user.role === 'Super Admin') {
+          this.isLoggedIn = true;
+        }
+      },
+      error: () => {
+        this.isLoggedIn = false;
+      }
+    });
+  }
+
+  login() {
+    if (this.form.invalid) {
+      return;
+    }
+
+    const { email, password } = this.form.value;
+
+    this.authService.loginSuperAdmin({ email, password }).subscribe({
+      next: () => {
+        this.isLoggedIn = true;
+      },
+      error: (err) => {
+        this.errorMessage = err?.error?.error || 'An error occurred, please try again.';
+      }
+    });
+  }
 }

--- a/SLFrontend/src/app/services/auth.service.ts
+++ b/SLFrontend/src/app/services/auth.service.ts
@@ -163,8 +163,25 @@ signin(credentials: { email: string; password: string }): Observable<any> {
     return this.http.patch(`${this.apiUrl}/client/profile/`, data);
   }
   loginSuperAdmin(data: { email: string; password: string }): Observable<any> {
-  return this.http.post(`${this.apiUrl}/login-superadmin/`, data);
-}
+    return this.http.post(`${this.apiUrl}/login-superadmin/`, data).pipe(
+      tap((response: any) => {
+        if (response.access && response.refresh) {
+          localStorage.setItem('access_token', response.access);
+          localStorage.setItem('refresh_token', response.refresh);
+          localStorage.setItem('role', response.role);
+          localStorage.setItem('user_id', response.user_id);
+          this.isClientLoggedInSubject.next(true);
+        }
+      }),
+      tap(() => {
+        this.getCurrentUser().subscribe();
+      }),
+      catchError(error => {
+        console.error('SuperAdmin Login Error:', error);
+        return throwError(() => new Error('Invalid credentials'));
+      })
+    );
+  }
 updateUserProfile(data:FormData){
   return this.http.patch(`${this.apiUrl}/updateuser/`, data)
 }

--- a/SLFrontend/src/main.ts
+++ b/SLFrontend/src/main.ts
@@ -74,7 +74,6 @@ const routes: Routes = [
     },
     { path: 'office-dashboard',
       component: OfficeDashboardComponent,
-      canActivate: [authGuard],
       children: [
         { path: '', component: WelcomeComponent },
         { path: 'live-work-board', component: LiveWorkBoardComponent },


### PR DESCRIPTION
## Summary
- add token handling to `loginSuperAdmin` service method
- display login form inside Office Dashboard when user isn't authenticated
- style the new login form
- prevent Super Admins from logging through the regular sign-in component
- expose Office Dashboard route without guard

## Testing
- `python SwiftLink/manage.py test`
- `npm test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_b_685bc2b72c4483248edb4c5080c4f1ec