### PR TITLE
Implement categorized order view

### DIFF
--- a/SLFrontend/src/app/office-dashboard/live-work-board/live-work-board.component.html
+++ b/SLFrontend/src/app/office-dashboard/live-work-board/live-work-board.component.html
@@ -1,19 +1,44 @@
 <div class="orders-container">
-    <h2>Orders</h2>
-    <ul>
-      <li *ngFor="let order of orders">
-        <div class="order-details">
-          <h3>{{ order.jobTitle }}</h3>
-          <p><strong>Address:</strong> {{ order.jobAddress }}</p>
-          <p><strong>Priority:</strong> 
-            <span [ngClass]="getPriorityClass(order.priorityLevel)">{{ order.priorityLevel }}</span>
-          </p>
-          <p><strong>Execution Date:</strong> {{ order.executionDate | date:'mediumDate' }}</p>
-          <p><strong>Expiration Time:</strong> {{ order.expirationTime | date:'shortTime' }}</p>
-          <p><strong>Resources:</strong> {{ order.jobResources }}</p>
-        </div>
-        
-      </li>
-    </ul>
-  </div>
+  <h2>Active / Not Assigned</h2>
+  <ul>
+    <li *ngFor="let order of activeUnassigned" (click)="toggleOrder(order.orderID)">
+      <h3>{{ order.jobTitle }}</h3>
+      <div class="order-details" *ngIf="expandedOrderId === order.orderID">
+        <p><strong>Address:</strong> {{ order.jobAddress }}</p>
+        <p><strong>Priority:</strong> <span [ngClass]="getPriorityClass(order.priorityLevel)">{{ order.priorityLevel }}</span></p>
+        <p><strong>Execution Date:</strong> {{ order.executionDate | date:'mediumDate' }}</p>
+        <p><strong>Expiration Time:</strong> {{ order.expirationTime | date:'shortTime' }}</p>
+        <p><strong>Resources:</strong> {{ order.jobResources }}</p>
+      </div>
+    </li>
+  </ul>
+
+  <h2>Active / Assigned</h2>
+  <ul>
+    <li *ngFor="let order of activeAssigned" (click)="toggleOrder(order.orderID)">
+      <h3>{{ order.jobTitle }}</h3>
+      <div class="order-details" *ngIf="expandedOrderId === order.orderID">
+        <p><strong>Address:</strong> {{ order.jobAddress }}</p>
+        <p><strong>Priority:</strong> <span [ngClass]="getPriorityClass(order.priorityLevel)">{{ order.priorityLevel }}</span></p>
+        <p><strong>Execution Date:</strong> {{ order.executionDate | date:'mediumDate' }}</p>
+        <p><strong>Expiration Time:</strong> {{ order.expirationTime | date:'shortTime' }}</p>
+        <p><strong>Resources:</strong> {{ order.jobResources }}</p>
+      </div>
+    </li>
+  </ul>
+
+  <h2>Past Work Orders</h2>
+  <ul>
+    <li *ngFor="let order of pastOrders" (click)="toggleOrder(order.orderID)">
+      <h3>{{ order.jobTitle }}</h3>
+      <div class="order-details" *ngIf="expandedOrderId === order.orderID">
+        <p><strong>Address:</strong> {{ order.jobAddress }}</p>
+        <p><strong>Priority:</strong> <span [ngClass]="getPriorityClass(order.priorityLevel)">{{ order.priorityLevel }}</span></p>
+        <p><strong>Execution Date:</strong> {{ order.executionDate | date:'mediumDate' }}</p>
+        <p><strong>Expiration Time:</strong> {{ order.expirationTime | date:'shortTime' }}</p>
+        <p><strong>Resources:</strong> {{ order.jobResources }}</p>
+      </div>
+    </li>
+  </ul>
+</div>
   

--- a/SLFrontend/src/app/office-dashboard/live-work-board/live-work-board.component.ts
+++ b/SLFrontend/src/app/office-dashboard/live-work-board/live-work-board.component.ts
@@ -10,6 +10,10 @@ import { CommonModule, NgFor } from '@angular/common';
 })
 export class LiveWorkBoardComponent implements OnInit {
   orders: any[] = [];
+  activeUnassigned: any[] = [];
+  activeAssigned: any[] = [];
+  pastOrders: any[] = [];
+  expandedOrderId: number | null = null;
   errorMessage: string = '';
   constructor(private orderService: OrderService) {}
 
@@ -19,7 +23,12 @@ export class LiveWorkBoardComponent implements OnInit {
 
   loadOrders(): void {
     this.orderService.getAllOrders().subscribe({
-      next: (data) => this.orders = data,
+      next: (data) => {
+        this.orders = data;
+        this.activeUnassigned = this.orders.filter(o => o.jobStatus !== 'Completed' && !o.assignedTo);
+        this.activeAssigned = this.orders.filter(o => o.jobStatus !== 'Completed' && o.assignedTo);
+        this.pastOrders = this.orders.filter(o => o.jobStatus === 'Completed');
+      },
       error: (err) => console.error('Error loading orders:', err)
     });
   }
@@ -35,6 +44,10 @@ export class LiveWorkBoardComponent implements OnInit {
         this.errorMessage = 'Failed to like order. Please try again!';
       }
     });
+  }
+
+  toggleOrder(orderID: number): void {
+    this.expandedOrderId = this.expandedOrderId === orderID ? null : orderID;
   }
   getPriorityClass(priority: string): string {
     switch (priority.toLowerCase()) {


### PR DESCRIPTION
## Summary
- categorize work orders into active/not assigned, active/assigned and past
- toggle order details on click

## Testing
- `npm ci --legacy-peer-deps`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_685bd135d63c832487b3faefbf49631f