### PR TITLE
Fix work orders dashboard

### DIFF
--- a/SLFrontend/src/app/office-dashboard/live-work-board/live-work-board.component.html
+++ b/SLFrontend/src/app/office-dashboard/live-work-board/live-work-board.component.html
@@ -1,7 +1,7 @@
 <div class="orders-container">
   <h2>Active / Not Assigned</h2>
   <ul>
-    <li *ngFor="let order of activeUnassigned" (click)="toggleOrder(order.order.orderID)">
+    <li *ngFor="let order of activeUnassigned; trackBy: trackById" (click)="toggleOrder(order.order.orderID)">
       <h3>{{ order.order.jobTitle }}</h3>
       <div class="order-details" *ngIf="expandedOrderId === order.order.orderID">
         <p><strong>Address:</strong> {{ order.order.jobAddress }}</p>
@@ -19,7 +19,7 @@
 
   <h2>Active / Assigned</h2>
   <ul>
-    <li *ngFor="let order of activeAssigned" (click)="toggleOrder(order.order.orderID)">
+    <li *ngFor="let order of activeAssigned; trackBy: trackById" (click)="toggleOrder(order.order.orderID)">
       <h3>{{ order.order.jobTitle }}</h3>
       <div class="order-details" *ngIf="expandedOrderId === order.order.orderID">
         <p><strong>Address:</strong> {{ order.order.jobAddress }}</p>
@@ -38,7 +38,7 @@
 
   <h2>Past Work Orders</h2>
   <ul>
-    <li *ngFor="let order of pastOrders" (click)="toggleOrder(order.order.orderID)">
+    <li *ngFor="let order of pastOrders; trackBy: trackById" (click)="toggleOrder(order.order.orderID)">
       <h3>{{ order.order.jobTitle }}</h3>
       <div class="order-details" *ngIf="expandedOrderId === order.order.orderID">
         <p><strong>Address:</strong> {{ order.order.jobAddress }}</p>

--- a/SLFrontend/src/app/office-dashboard/live-work-board/live-work-board.component.ts
+++ b/SLFrontend/src/app/office-dashboard/live-work-board/live-work-board.component.ts
@@ -57,5 +57,9 @@ export class LiveWorkBoardComponent implements OnInit {
       default: return '';
     }
   }
-  
+
+  trackById(index: number, item: any): number {
+    return item.order?.orderID;
+  }
+
 }

--- a/SLFrontend/src/app/services/order.service.ts
+++ b/SLFrontend/src/app/services/order.service.ts
@@ -73,6 +73,15 @@ export class OrderService {
   }
 
   getWorkOrdersDashboard() {
-    return this.http.get<any>(`${environment.apiUrl}/dashboard/work-orders/`);
+    const token = localStorage.getItem('access_token');
+    if (!token) {
+      console.error('No access token found!');
+      return new Observable();
+    }
+    const headers = new HttpHeaders({
+      'Authorization': `Bearer ${token}`
+    });
+
+    return this.http.get<any>(`${environment.apiUrl}/dashboard/work-orders/`, { headers });
   }
 }

--- a/SwiftLink/Order/views.py
+++ b/SwiftLink/Order/views.py
@@ -269,6 +269,7 @@ def work_orders_dashboard(request):
             'firstName': client.UserId.first_name,
             'lastName': client.UserId.last_name,
             'address': client.address,
+            'phone': client.phone,
         }
         data.append({
             'order': order_data,


### PR DESCRIPTION
## Summary
- authenticate dashboard work order API calls
- include phone number in work orders dashboard API
- stabilize live work board rows with trackBy

## Testing
- `pytest -q`
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_685bdbecb848832495e8b3ea2c3cf85d