### PR TITLE
Fix invalid date in work orders table

### DIFF
--- a/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.html
+++ b/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.html
@@ -108,7 +108,7 @@
   </thead>
   <tbody>
     <tr *ngFor="let o of filteredOrders">
-      <td>{{ o.order.executionDate | date:'shortDate' }}</td>
+      <td>{{ o.order.executionDate ? (o.order.executionDate | date:'shortDate') : (o.order.creationDate | date:'shortDate') }}</td>
       <td>{{ o.order.orderID }}</td>
       <td>{{ o.workforce?.firstName || 'N/A' }} {{ o.workforce?.lastName || '' }}</td>
       <td>{{ o.client?.firstName || 'N/A' }} {{ o.client?.lastName || '' }}</td>


### PR DESCRIPTION
## Summary
- handle missing execution date when displaying work orders

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_685be9534650832482e4ddd772747601