### PR TITLE
Fix work orders dashboard metrics

### DIFF
--- a/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.html
+++ b/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.html
@@ -72,7 +72,12 @@
   <div class="summary-card">
     <h4>Collected ISF</h4>
     <p class="value">{{salesSummary.collectedIsf | currency:'USD':'symbol':'1.2-2'}}</p>
-    
+
+  </div>
+  <div class="summary-card">
+    <h4>Collected Membership</h4>
+    <p class="value">{{salesSummary.collectedMembership | currency:'USD':'symbol':'1.2-2'}}</p>
+
   </div>
   <div class="summary-card">
     <h4>Pending Payments</h4>


### PR DESCRIPTION
## Summary
- correct dashboard summary calculations
- show collected membership in work orders dashboard
- parse invoice durations properly

## Testing
- `python SwiftLink/manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_685bf1206e188324ab24e2f982f07e1b