### PR TITLE
Fix duration type in work orders

### DIFF
--- a/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.ts
+++ b/SLFrontend/src/app/office-dashboard/work-orders/work-orders.component.ts
@@ -182,9 +182,12 @@ export class WorkOrdersComponent implements OnInit {
     return Number(record.invoice?.baseAmount || 0) * 0.10;
   }
 
-  private durationToHours(duration?: string | null): number {
-    if (!duration) {
+  private durationToHours(duration?: string | number | null): number {
+    if (duration == null) {
       return 0;
+    }
+    if (typeof duration === 'number') {
+      return duration;
     }
     let days = 0;
     let timePart = duration;


### PR DESCRIPTION
## Summary
- support numeric values in `durationToHours`

## Testing
- `npx ng build`
- `npx ng test --watch=false` *(fails: Module not found: profile.component.scss)*

------
https://chatgpt.com/codex/tasks/task_b_685bf337814c832491a47620e1375ff7