### PR TITLE
Fix missing Workforce and Invoice fields

### DIFF
--- a/SLFrontend/src/app/models/invoice.model.ts
+++ b/SLFrontend/src/app/models/invoice.model.ts
@@ -7,6 +7,7 @@ export interface Invoice {
   invoiceID: number;
   orderID: number;
   helperID: number;
+  helper?: number;
   serviceType: string;
   duration: number; // hours worked
   unitPrice: number;

--- a/SLFrontend/src/app/models/user.model.ts
+++ b/SLFrontend/src/app/models/user.model.ts
@@ -44,6 +44,8 @@ export interface Client extends User {
 export interface Workforce extends User {
   phone: string;
   gender: Gender;  // ✅ Utilisation de l'énumération
+  professionnelemail?: string;
+  UserId?: number | { email: string };
   driverLicence?: string;
   driverLicenceExpiry?: string | null ;
   credentials?: string;


### PR DESCRIPTION
## Summary
- add `professionnelemail` and `UserId` fields to `Workforce` interface
- include optional `helper` id in `Invoice`

## Testing
- `npm test` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_b_685bfac997ac8324a9cac1535c3d6bb8