### PR TITLE
Fix null client references in WorkSchedules

### DIFF
--- a/SLFrontend/src/app/office-dashboard/work-schedules/work-schedules.component.html
+++ b/SLFrontend/src/app/office-dashboard/work-schedules/work-schedules.component.html
@@ -19,8 +19,8 @@
       <p *ngIf="selectedOrder.order.jobStatus === 'Completed'"><strong>Duration:</strong> {{ selectedOrder.order.orderDuration }}</p>
       <p *ngIf="selectedOrder.order.manpower"><strong>Manpower:</strong> {{ selectedOrder.order.manpower }}</p>
       <p *ngIf="selectedOrder.order.jobResources"><strong>Resources:</strong> {{ selectedOrder.order.jobResources }}</p>
-      <p><strong>Client:</strong> {{ selectedOrder.client.firstName }} {{ selectedOrder.client.lastName }}</p>
-      <p><strong>Client Phone:</strong> {{ selectedOrder.client.phone }}</p>
+      <p><strong>Client:</strong> {{ selectedOrder.client?.firstName }} {{ selectedOrder.client?.lastName }}</p>
+      <p><strong>Client Phone:</strong> {{ selectedOrder.client?.phone }}</p>
       <button (click)="clearSelectedOrder()">Close</button>
     </div>
 


### PR DESCRIPTION
## Summary
- guard against null `client` in WorkSchedules view

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c0795420483248b1e2146efc31874