### PR TITLE
Fix promo alignment and membership price labels

### DIFF
--- a/SLFrontend/src/app/auth/signin/signin.component.css
+++ b/SLFrontend/src/app/auth/signin/signin.component.css
@@ -51,11 +51,11 @@ h1 {
 }
 
 .promo-input {
-  width: 100%;
+  flex: 1;
   padding: 10px;
   border-radius: 6px;
   border: 1px solid #ccc;
-  margin-bottom: 1.5rem;
+  margin-bottom: 0;
 }
 
 h3 {
@@ -110,6 +110,7 @@ h3 {
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 1.5rem;
+  width: 100%;
 }
 
 .promo-label {

--- a/SLFrontend/src/app/auth/signin/signin.component.html
+++ b/SLFrontend/src/app/auth/signin/signin.component.html
@@ -27,7 +27,9 @@
         <input type="radio" name="membership" [value]="m.membershipType" [(ngModel)]="selectedMembership" />
         <div class="plan-title">
           <span class="plan-name">{{ m.membershipType }}</span>
-          <span class="plan-price">${{ m.cost }}</span>
+          <span class="plan-price">
+            ${{ m.cost }}<span *ngIf="m.membershipType.toLowerCase() === 'preferred' || m.membershipType.toLowerCase() === 'ultimate'">/month</span>
+          </span>
         </div>
         <div class="plan-desc">
           <ng-container [ngSwitch]="m.membershipType.toLowerCase()">


### PR DESCRIPTION
## Summary
- align promo code field elements on signin page
- clarify monthly pricing for Preferred and Ultimate options

## Testing
- `npm test --silent -- --watch=false` *(fails: Module not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d0f561ffc8324851abed95e5a2668