### PR TITLE
Adjust promo signup messaging and membership billing

### DIFF
--- a/SLFrontend/src/app/auth/signup/signup.component.ts
+++ b/SLFrontend/src/app/auth/signup/signup.component.ts
@@ -21,6 +21,7 @@ export class SignupComponent implements OnInit {
   clientTypes = Object.values(ClientType);
   membershipType: MembershipType | null = null;
   promoMessage = '';
+  hasPromo = false;
   errorMessage = '';
   clientForm: Client = {
     email: '',
@@ -75,6 +76,7 @@ export class SignupComponent implements OnInit {
       const promo = params.get('promo');
       if (promo === 'true') {
         this.promoMessage = 'Sign-up with promotion code 1 free month';
+        this.hasPromo = true;
       }
     });
   }
@@ -89,7 +91,9 @@ export class SignupComponent implements OnInit {
             email: this.clientForm.email,
             password: this.clientForm.password
           }).subscribe(() => {
-            if (this.membershipType === MembershipType.PAY_PER_USE) {
+            if (this.hasPromo) {
+              alert('Your account is fully active. You have one free month');
+            } else if (this.membershipType === MembershipType.PAY_PER_USE) {
               alert('Your account is now fully active. Your free month will begin when you place your first work order');
             } else {
               alert('Your account is now fully active. your membership fee will be added to your first job, which will also mark the start of your monthly membership period');


### PR DESCRIPTION
## Summary
- show a custom message when signing up with a promo code
- track promo signup on the frontend
- bill membership fees monthly and honor free month promo logic

## Testing
- `python SwiftLink/manage.py test`
- `npm test --silent` *(fails: Could not find the '@angular-devkit/build-angular:karma' builder)*

------
https://chatgpt.com/codex/tasks/task_b_685d17a262f0832485e13cc14979e07f