### PR TITLE
Split profile pages and adjust password update

### DIFF
--- a/SLFrontend/src/app/admin-profile/admin-profile.component.css
+++ b/SLFrontend/src/app/admin-profile/admin-profile.component.css
@@ -1,0 +1,173 @@
+.profile-container {
+    max-width: 500px;
+    margin: 40px auto;
+    padding: 30px;
+    border-radius: 10px;
+    background: #f9f9f9;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    font-family: 'Segoe UI', sans-serif;
+  }
+  
+  .profile-container h2 {
+    text-align: center;
+    margin-bottom: 20px;
+    color: #002f5f;
+  }
+  
+  .profile-image {
+    text-align: center;
+    margin-bottom: 20px;
+  }
+  
+  .profile-image img {
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid #ccc;
+  }
+  
+  .profile-image input {
+    margin-top: 10px;
+  }
+  
+  label {
+    display: block;
+    margin: 10px 0 4px;
+    font-weight: bold;
+    color: #333;
+  }
+  
+  input {
+    width: 100%;
+    padding: 10px;
+    border-radius: 6px;
+    border: 1px solid #ccc;
+    margin-bottom: 15px;
+  }
+  
+  button {
+    width: 100%;
+    background-color: #002f5f;
+    color: white;
+    padding: 12px;
+    font-size: 16px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  
+  button:hover {
+    background-color: #004080;
+  }
+ 
+  
+  .editable-field label {
+    font-weight: bold;
+    display: block;
+    margin-bottom: 5px;
+  }
+  
+  .editable-field button {
+    background: none;
+    border: none;
+    color: #007bff;
+    cursor: pointer;
+    margin-left: 10px;
+  }
+  
+  .error {
+    color: red;
+    font-size: 12px;
+    margin-top: 4px;
+  }
+  .success-message {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+    padding: 10px;
+    border-radius: 6px;
+    margin-bottom: 15px;
+    text-align: center;
+  }
+  
+  .error-message {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+    padding: 10px;
+    border-radius: 6px;
+    margin-bottom: 15px;
+    text-align: center;
+  }
+  .editable-field {
+    
+  margin-bottom: 30px;
+}
+
+.editable-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: bold;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+.editable-label label {
+  margin: 0;
+  font-weight: bold;
+  font-size: 15px;
+}
+
+.edit-icon {
+  background: none;
+  border: none;
+  font-size: 18px;
+  color: #ff5722;
+  cursor: pointer;
+  padding: 0;
+}
+
+.edit-icon:hover {
+  transform: scale(1.1);
+}
+
+.edit-input {
+  width: 100%;
+  padding: 10px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+.label-with-icon {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.label-with-icon label {
+  font-weight: 600;
+  margin: 0;
+}
+
+.edit-icon {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0;
+  color: #ff5722;
+}
+
+.address-text {
+  font-weight: normal;
+  color: #333;
+  margin-top: 4px;
+}
+
+
+  
+  
+  

--- a/SLFrontend/src/app/admin-profile/admin-profile.component.html
+++ b/SLFrontend/src/app/admin-profile/admin-profile.component.html
@@ -1,0 +1,63 @@
+<div class="profile-container">
+    <h2>Profile Settings</h2>
+  
+    <form [formGroup]="form" (ngSubmit)="onSubmit()" enctype="multipart/form-data">
+      
+      <!-- Image -->
+      <div class="profile-image">
+        <img [src]="profileImageUrl " alt="Profile" />
+        <input type="file" (change)="onFileChange($event)" />
+      </div>
+  
+      <!-- Email avec bouton d’édition -->
+      <div class="editable-field">
+        <label>Email</label>
+        <div *ngIf="!editingEmail">
+          {{ form.get('email')?.value }}
+          
+        </div>
+        <input *ngIf="editingEmail" type="email" formControlName="email" />
+        <div *ngIf="form.get('email')?.invalid && form.get('email')?.touched" class="error">Invalid email</div>
+      </div>
+  
+    <div class="editable-field">
+  <!-- Ligne : "Address" + ✏️ -->
+  <div class="label-with-icon">
+    <label>Address</label>
+    <button type="button" class="edit-icon" (click)="toggleEdit('address')">✏️</button>
+  </div>
+
+  <!-- Ligne suivante : valeur -->
+  <div *ngIf="!editingAddress" class="address-text">
+    {{ form.get('address')?.value }}
+  </div>
+
+  <!-- Champ en édition -->
+  <input *ngIf="editingAddress" type="text" formControlName="address" class="edit-input" />
+</div>
+
+
+      <!--phone number-->
+      <!-- Carte (à intégrer plus tard avec coords/map component) -->
+      <!-- <app-map (addressSelected)="updateAddress($event)"></app-map> -->
+  
+      <!-- Password -->
+      <label>Change Password</label>
+      <input type="password" formControlName="oldPassword" placeholder="Current Password" />
+      <input type="password" formControlName="newPassword" placeholder="New Password" />
+      <input type="password" formControlName="confirmPassword" placeholder="Confirm New Password" />
+      <div *ngIf="form.hasError('passwordMismatch') && form.get('confirmPassword')?.touched" class="error">
+        Passwords do not match
+      </div>
+  
+      <button type="submit" [disabled]="form.invalid">Save Changes</button>
+    </form>
+    <div *ngIf="successMessage" class="success-message">
+        {{ successMessage }}
+      </div>
+      
+      <div *ngIf="errorMessage" class="error-message">
+        {{ errorMessage }}
+      </div>
+  </div>
+  

--- a/SLFrontend/src/app/admin-profile/admin-profile.component.ts
+++ b/SLFrontend/src/app/admin-profile/admin-profile.component.ts
@@ -1,0 +1,151 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, AbstractControl, ReactiveFormsModule } from '@angular/forms';
+import { AuthService } from '../services/auth.service';
+import { CommonModule } from '@angular/common';
+import { environment } from '../../environments/environment';
+
+@Component({
+  selector: 'app-admin-profile',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './admin-profile.component.html',
+  styleUrls: ['./admin-profile.component.css']
+})
+export class AdminProfileComponent implements OnInit {
+  form: FormGroup;
+  user: any;
+  selectedImageFile: File | null = null;
+  profilePreview: string | ArrayBuffer | null = null;
+
+  editingEmail = false;
+  editingAddress = false;
+  successMessage: string = '';
+  errorMessage: string = '';
+
+  BACKEND_URL = 'https://www.swift-helpers.com';
+
+  constructor(private fb: FormBuilder, private authService: AuthService) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+      address: ['', Validators.required],
+      oldPassword: [''],
+      newPassword: [''],
+      confirmPassword: [''],
+    }, { validators: this.passwordMatchValidator });
+  }
+
+  get profileImageUrl(): string {
+    return this.profilePreview
+      ? this.profilePreview.toString()
+      : (this.user?.profileImage ? `${this.BACKEND_URL}${this.user.profileImage}` : '/default-user.jpg');
+  }
+
+ngOnInit(): void {
+  this.authService.getCurrentUser().subscribe(user => {
+    this.user = user;
+    
+    this.profilePreview = user.profileImage ? `${this.BACKEND_URL}${user.profileImage}` : null;
+
+    let address = '';
+
+    // Si c’est un client
+    if (user.role === 'Client' && user.client && user.client.address) {
+      address = user.client.address;
+      
+    }
+
+    // Si c’est un helper (workforce)
+    if (user.role === '3rd Party' && user.workforce && user.workforce.address) {
+      address = user.workforce.address;
+      
+    }
+
+    this.form.patchValue({
+      email: user.email,
+      address: address
+    });
+
+    this.form.get('email')?.disable();
+    this.form.get('address')?.disable();
+  });
+}
+
+
+  toggleEdit(field: 'email' | 'address'): void {
+    if (field === 'email') {
+      this.editingEmail = true;
+      this.form.get('email')?.enable();
+    } else if (field === 'address') {
+      this.editingAddress = true;
+      this.form.get('address')?.enable();
+    }
+  }
+
+  passwordMatchValidator(group: AbstractControl): { [key: string]: boolean } | null {
+    const newPass = group.get('newPassword')?.value;
+    const confirmPass = group.get('confirmPassword')?.value;
+    return newPass && confirmPass && newPass !== confirmPass ? { passwordMismatch: true } : null;
+  }
+
+  onFileChange(event: any): void {
+    const file = event.target.files[0];
+    if (file) {
+      this.selectedImageFile = file;
+
+      // Prévisualisation immédiate
+      const reader = new FileReader();
+      reader.onload = (e: any) => {
+        this.profilePreview = e.target.result;
+      };
+      reader.readAsDataURL(file);
+    }
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) return;
+
+    const formData = new FormData();
+
+    const email = this.form.getRawValue().email;
+    const address = this.form.getRawValue().address;
+
+    if (email) formData.append('email', email);
+    if (address) formData.append('address', address);
+
+    // Mots de passe (si modifiés)
+    if (this.form.value.newPassword) {
+      formData.append('password', this.form.value.newPassword);
+    }
+
+    // Fichier image sélectionné
+    if (this.selectedImageFile) {
+      formData.append('profileImage', this.selectedImageFile);
+    }
+
+    this.authService.updateUserProfile(formData).subscribe({
+      next: () => {
+        this.successMessage = '✅ Profile updated successfully!';
+        this.errorMessage = '';
+        this.editingEmail = false;
+        this.editingAddress = false;
+
+        // Reset password fields
+        this.form.get('oldPassword')?.reset();
+        this.form.get('newPassword')?.reset();
+        this.form.get('confirmPassword')?.reset();
+
+        // Réinitialiser les champs modifiables
+        this.form.get('email')?.disable();
+        this.form.get('address')?.disable();
+
+        setTimeout(() => this.successMessage = '', 4000);
+      },
+      error: (err) => {
+        this.errorMessage = '❌ Failed to update profile.';
+        this.successMessage = '';
+        console.error(err);
+        setTimeout(() => this.errorMessage = '', 5000);
+      }
+    });
+  }
+}

--- a/SLFrontend/src/app/client-profile/client-profile.component.css
+++ b/SLFrontend/src/app/client-profile/client-profile.component.css
@@ -1,0 +1,173 @@
+.profile-container {
+    max-width: 500px;
+    margin: 40px auto;
+    padding: 30px;
+    border-radius: 10px;
+    background: #f9f9f9;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    font-family: 'Segoe UI', sans-serif;
+  }
+  
+  .profile-container h2 {
+    text-align: center;
+    margin-bottom: 20px;
+    color: #002f5f;
+  }
+  
+  .profile-image {
+    text-align: center;
+    margin-bottom: 20px;
+  }
+  
+  .profile-image img {
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid #ccc;
+  }
+  
+  .profile-image input {
+    margin-top: 10px;
+  }
+  
+  label {
+    display: block;
+    margin: 10px 0 4px;
+    font-weight: bold;
+    color: #333;
+  }
+  
+  input {
+    width: 100%;
+    padding: 10px;
+    border-radius: 6px;
+    border: 1px solid #ccc;
+    margin-bottom: 15px;
+  }
+  
+  button {
+    width: 100%;
+    background-color: #002f5f;
+    color: white;
+    padding: 12px;
+    font-size: 16px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  
+  button:hover {
+    background-color: #004080;
+  }
+ 
+  
+  .editable-field label {
+    font-weight: bold;
+    display: block;
+    margin-bottom: 5px;
+  }
+  
+  .editable-field button {
+    background: none;
+    border: none;
+    color: #007bff;
+    cursor: pointer;
+    margin-left: 10px;
+  }
+  
+  .error {
+    color: red;
+    font-size: 12px;
+    margin-top: 4px;
+  }
+  .success-message {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+    padding: 10px;
+    border-radius: 6px;
+    margin-bottom: 15px;
+    text-align: center;
+  }
+  
+  .error-message {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+    padding: 10px;
+    border-radius: 6px;
+    margin-bottom: 15px;
+    text-align: center;
+  }
+  .editable-field {
+    
+  margin-bottom: 30px;
+}
+
+.editable-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: bold;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+.editable-label label {
+  margin: 0;
+  font-weight: bold;
+  font-size: 15px;
+}
+
+.edit-icon {
+  background: none;
+  border: none;
+  font-size: 18px;
+  color: #ff5722;
+  cursor: pointer;
+  padding: 0;
+}
+
+.edit-icon:hover {
+  transform: scale(1.1);
+}
+
+.edit-input {
+  width: 100%;
+  padding: 10px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+.label-with-icon {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.label-with-icon label {
+  font-weight: 600;
+  margin: 0;
+}
+
+.edit-icon {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0;
+  color: #ff5722;
+}
+
+.address-text {
+  font-weight: normal;
+  color: #333;
+  margin-top: 4px;
+}
+
+
+  
+  
+  

--- a/SLFrontend/src/app/client-profile/client-profile.component.html
+++ b/SLFrontend/src/app/client-profile/client-profile.component.html
@@ -1,0 +1,68 @@
+<div class="profile-container">
+    <h2>Profile Settings</h2>
+  
+    <form [formGroup]="form" (ngSubmit)="onSubmit()" enctype="multipart/form-data">
+      
+      <!-- Image -->
+      <div class="profile-image">
+        <img [src]="profileImageUrl " alt="Profile" />
+        <input type="file" (change)="onFileChange($event)" />
+      </div>
+
+      <div class="membership-field">
+        <label>Membership Type</label>
+        <span>{{ membershipType || 'N/A' }}</span>
+      </div>
+  
+      <!-- Email avec bouton d’édition -->
+      <div class="editable-field">
+        <label>Email</label>
+        <div *ngIf="!editingEmail">
+          {{ form.get('email')?.value }}
+          
+        </div>
+        <input *ngIf="editingEmail" type="email" formControlName="email" />
+        <div *ngIf="form.get('email')?.invalid && form.get('email')?.touched" class="error">Invalid email</div>
+      </div>
+  
+    <div class="editable-field">
+  <!-- Ligne : "Address" + ✏️ -->
+  <div class="label-with-icon">
+    <label>Address</label>
+    <button type="button" class="edit-icon" (click)="toggleEdit('address')">✏️</button>
+  </div>
+
+  <!-- Ligne suivante : valeur -->
+  <div *ngIf="!editingAddress" class="address-text">
+    {{ form.get('address')?.value }}
+  </div>
+
+  <!-- Champ en édition -->
+  <input *ngIf="editingAddress" type="text" formControlName="address" class="edit-input" />
+</div>
+
+
+      <!--phone number-->
+      <!-- Carte (à intégrer plus tard avec coords/map component) -->
+      <!-- <app-map (addressSelected)="updateAddress($event)"></app-map> -->
+  
+      <!-- Password -->
+      <label>Change Password</label>
+      <input type="password" formControlName="oldPassword" placeholder="Current Password" />
+      <input type="password" formControlName="newPassword" placeholder="New Password" />
+      <input type="password" formControlName="confirmPassword" placeholder="Confirm New Password" />
+      <div *ngIf="form.hasError('passwordMismatch') && form.get('confirmPassword')?.touched" class="error">
+        Passwords do not match
+      </div>
+  
+      <button type="submit" [disabled]="form.invalid">Save Changes</button>
+    </form>
+    <div *ngIf="successMessage" class="success-message">
+        {{ successMessage }}
+      </div>
+      
+      <div *ngIf="errorMessage" class="error-message">
+        {{ errorMessage }}
+      </div>
+  </div>
+  

--- a/SLFrontend/src/app/client-profile/client-profile.component.ts
+++ b/SLFrontend/src/app/client-profile/client-profile.component.ts
@@ -1,0 +1,154 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, AbstractControl, ReactiveFormsModule } from '@angular/forms';
+import { AuthService } from '../services/auth.service';
+import { CommonModule } from '@angular/common';
+import { environment } from '../../environments/environment';
+
+@Component({
+  selector: 'app-client-profile',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './client-profile.component.html',
+  styleUrls: ['./client-profile.component.css']
+})
+export class ClientProfileComponent implements OnInit {
+  form: FormGroup;
+  user: any;
+  membershipType: string | null = null;
+  selectedImageFile: File | null = null;
+  profilePreview: string | ArrayBuffer | null = null;
+
+  editingEmail = false;
+  editingAddress = false;
+  successMessage: string = '';
+  errorMessage: string = '';
+
+  BACKEND_URL = 'https://www.swift-helpers.com';
+
+  constructor(private fb: FormBuilder, private authService: AuthService) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+      address: ['', Validators.required],
+      oldPassword: [''],
+      newPassword: [''],
+      confirmPassword: [''],
+    }, { validators: this.passwordMatchValidator });
+  }
+
+  get profileImageUrl(): string {
+    return this.profilePreview
+      ? this.profilePreview.toString()
+      : (this.user?.profileImage ? `${this.BACKEND_URL}${this.user.profileImage}` : '/default-user.jpg');
+  }
+
+ngOnInit(): void {
+  this.authService.getCurrentUser().subscribe(user => {
+    this.user = user;
+
+    this.profilePreview = user.profileImage ? `${this.BACKEND_URL}${user.profileImage}` : null;
+
+    let address = '';
+
+    // Si c’est un client
+    if (user.role === 'Client' && user.client) {
+      if (user.client.address) {
+        address = user.client.address;
+      }
+      this.membershipType = user.client.membershipType || null;
+    }
+
+    // Si c’est un helper (workforce)
+    if (user.role === '3rd Party' && user.workforce && user.workforce.address) {
+      address = user.workforce.address;
+      
+    }
+
+    this.form.patchValue({
+      email: user.email,
+      address: address
+    });
+
+    this.form.get('email')?.disable();
+    this.form.get('address')?.disable();
+  });
+}
+
+
+  toggleEdit(field: 'email' | 'address'): void {
+    if (field === 'email') {
+      this.editingEmail = true;
+      this.form.get('email')?.enable();
+    } else if (field === 'address') {
+      this.editingAddress = true;
+      this.form.get('address')?.enable();
+    }
+  }
+
+  passwordMatchValidator(group: AbstractControl): { [key: string]: boolean } | null {
+    const newPass = group.get('newPassword')?.value;
+    const confirmPass = group.get('confirmPassword')?.value;
+    return newPass && confirmPass && newPass !== confirmPass ? { passwordMismatch: true } : null;
+  }
+
+  onFileChange(event: any): void {
+    const file = event.target.files[0];
+    if (file) {
+      this.selectedImageFile = file;
+
+      // Prévisualisation immédiate
+      const reader = new FileReader();
+      reader.onload = (e: any) => {
+        this.profilePreview = e.target.result;
+      };
+      reader.readAsDataURL(file);
+    }
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) return;
+
+    const formData = new FormData();
+
+    const email = this.form.getRawValue().email;
+    const address = this.form.getRawValue().address;
+
+    if (email) formData.append('email', email);
+    if (address) formData.append('address', address);
+
+    // Mots de passe (si modifiés)
+    if (this.form.value.newPassword) {
+      formData.append('password', this.form.value.newPassword);
+    }
+
+    // Fichier image sélectionné
+    if (this.selectedImageFile) {
+      formData.append('profileImage', this.selectedImageFile);
+    }
+
+    this.authService.updateUserProfile(formData).subscribe({
+      next: () => {
+        this.successMessage = '✅ Profile updated successfully!';
+        this.errorMessage = '';
+        this.editingEmail = false;
+        this.editingAddress = false;
+
+        // Reset password fields
+        this.form.get('oldPassword')?.reset();
+        this.form.get('newPassword')?.reset();
+        this.form.get('confirmPassword')?.reset();
+
+        // Réinitialiser les champs modifiables
+        this.form.get('email')?.disable();
+        this.form.get('address')?.disable();
+
+        setTimeout(() => this.successMessage = '', 4000);
+      },
+      error: (err) => {
+        this.errorMessage = '❌ Failed to update profile.';
+        this.successMessage = '';
+        console.error(err);
+        setTimeout(() => this.errorMessage = '', 5000);
+      }
+    });
+  }
+}

--- a/SLFrontend/src/app/helper-profile-edit/helper-profile-edit.component.css
+++ b/SLFrontend/src/app/helper-profile-edit/helper-profile-edit.component.css
@@ -1,0 +1,173 @@
+.profile-container {
+    max-width: 500px;
+    margin: 40px auto;
+    padding: 30px;
+    border-radius: 10px;
+    background: #f9f9f9;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    font-family: 'Segoe UI', sans-serif;
+  }
+  
+  .profile-container h2 {
+    text-align: center;
+    margin-bottom: 20px;
+    color: #002f5f;
+  }
+  
+  .profile-image {
+    text-align: center;
+    margin-bottom: 20px;
+  }
+  
+  .profile-image img {
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid #ccc;
+  }
+  
+  .profile-image input {
+    margin-top: 10px;
+  }
+  
+  label {
+    display: block;
+    margin: 10px 0 4px;
+    font-weight: bold;
+    color: #333;
+  }
+  
+  input {
+    width: 100%;
+    padding: 10px;
+    border-radius: 6px;
+    border: 1px solid #ccc;
+    margin-bottom: 15px;
+  }
+  
+  button {
+    width: 100%;
+    background-color: #002f5f;
+    color: white;
+    padding: 12px;
+    font-size: 16px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  
+  button:hover {
+    background-color: #004080;
+  }
+ 
+  
+  .editable-field label {
+    font-weight: bold;
+    display: block;
+    margin-bottom: 5px;
+  }
+  
+  .editable-field button {
+    background: none;
+    border: none;
+    color: #007bff;
+    cursor: pointer;
+    margin-left: 10px;
+  }
+  
+  .error {
+    color: red;
+    font-size: 12px;
+    margin-top: 4px;
+  }
+  .success-message {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+    padding: 10px;
+    border-radius: 6px;
+    margin-bottom: 15px;
+    text-align: center;
+  }
+  
+  .error-message {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+    padding: 10px;
+    border-radius: 6px;
+    margin-bottom: 15px;
+    text-align: center;
+  }
+  .editable-field {
+    
+  margin-bottom: 30px;
+}
+
+.editable-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: bold;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+.editable-label label {
+  margin: 0;
+  font-weight: bold;
+  font-size: 15px;
+}
+
+.edit-icon {
+  background: none;
+  border: none;
+  font-size: 18px;
+  color: #ff5722;
+  cursor: pointer;
+  padding: 0;
+}
+
+.edit-icon:hover {
+  transform: scale(1.1);
+}
+
+.edit-input {
+  width: 100%;
+  padding: 10px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+.label-with-icon {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.label-with-icon label {
+  font-weight: 600;
+  margin: 0;
+}
+
+.edit-icon {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0;
+  color: #ff5722;
+}
+
+.address-text {
+  font-weight: normal;
+  color: #333;
+  margin-top: 4px;
+}
+
+
+  
+  
+  

--- a/SLFrontend/src/app/helper-profile-edit/helper-profile-edit.component.html
+++ b/SLFrontend/src/app/helper-profile-edit/helper-profile-edit.component.html
@@ -1,0 +1,64 @@
+<div class="profile-container">
+    <h2>Profile Settings</h2>
+  
+    <form [formGroup]="form" (ngSubmit)="onSubmit()" enctype="multipart/form-data">
+      
+      <!-- Image -->
+      <div class="profile-image">
+        <img [src]="profileImageUrl " alt="Profile" />
+        <input type="file" (change)="onFileChange($event)" />
+      </div>
+  
+      <!-- Email avec bouton d’édition -->
+      <div class="editable-field">
+        <label>Email</label>
+        <div *ngIf="!editingEmail">
+          {{ form.get('email')?.value }}
+          
+        </div>
+        <input *ngIf="editingEmail" type="email" formControlName="email" />
+        <div *ngIf="form.get('email')?.invalid && form.get('email')?.touched" class="error">Invalid email</div>
+      </div>
+  
+    <div class="editable-field">
+  <!-- Ligne : "Address" + ✏️ -->
+  <div class="label-with-icon">
+    <label>Address</label>
+    <button type="button" class="edit-icon" (click)="toggleEdit('address')">✏️</button>
+  </div>
+
+  <!-- Ligne suivante : valeur -->
+  <div *ngIf="!editingAddress" class="address-text">
+    {{ form.get('address')?.value }}
+  </div>
+
+  <!-- Champ en édition -->
+  <input *ngIf="editingAddress" type="text" formControlName="address" class="edit-input" />
+</div>
+<p class="membership-info">Monthly membership : 60$</p>
+
+
+      <!--phone number-->
+      <!-- Carte (à intégrer plus tard avec coords/map component) -->
+      <!-- <app-map (addressSelected)="updateAddress($event)"></app-map> -->
+  
+      <!-- Password -->
+      <label>Change Password</label>
+      <input type="password" formControlName="oldPassword" placeholder="Current Password" />
+      <input type="password" formControlName="newPassword" placeholder="New Password" />
+      <input type="password" formControlName="confirmPassword" placeholder="Confirm New Password" />
+      <div *ngIf="form.hasError('passwordMismatch') && form.get('confirmPassword')?.touched" class="error">
+        Passwords do not match
+      </div>
+  
+      <button type="submit" [disabled]="form.invalid">Save Changes</button>
+    </form>
+    <div *ngIf="successMessage" class="success-message">
+        {{ successMessage }}
+      </div>
+      
+      <div *ngIf="errorMessage" class="error-message">
+        {{ errorMessage }}
+      </div>
+  </div>
+  

--- a/SLFrontend/src/app/helper-profile-edit/helper-profile-edit.component.ts
+++ b/SLFrontend/src/app/helper-profile-edit/helper-profile-edit.component.ts
@@ -1,0 +1,151 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, AbstractControl, ReactiveFormsModule } from '@angular/forms';
+import { AuthService } from '../services/auth.service';
+import { CommonModule } from '@angular/common';
+import { environment } from '../../environments/environment';
+
+@Component({
+  selector: 'app-helper-profile',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './helper-profile-edit.component.html',
+  styleUrls: ['./helper-profile-edit.component.css']
+})
+export class HelperProfileEditComponent implements OnInit {
+  form: FormGroup;
+  user: any;
+  selectedImageFile: File | null = null;
+  profilePreview: string | ArrayBuffer | null = null;
+
+  editingEmail = false;
+  editingAddress = false;
+  successMessage: string = '';
+  errorMessage: string = '';
+
+  BACKEND_URL = 'https://www.swift-helpers.com';
+
+  constructor(private fb: FormBuilder, private authService: AuthService) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+      address: ['', Validators.required],
+      oldPassword: [''],
+      newPassword: [''],
+      confirmPassword: [''],
+    }, { validators: this.passwordMatchValidator });
+  }
+
+  get profileImageUrl(): string {
+    return this.profilePreview
+      ? this.profilePreview.toString()
+      : (this.user?.profileImage ? `${this.BACKEND_URL}${this.user.profileImage}` : '/default-user.jpg');
+  }
+
+ngOnInit(): void {
+  this.authService.getCurrentUser().subscribe(user => {
+    this.user = user;
+    
+    this.profilePreview = user.profileImage ? `${this.BACKEND_URL}${user.profileImage}` : null;
+
+    let address = '';
+
+    // Si c’est un client
+    if (user.role === 'Client' && user.client && user.client.address) {
+      address = user.client.address;
+      
+    }
+
+    // Si c’est un helper (workforce)
+    if (user.role === '3rd Party' && user.workforce && user.workforce.address) {
+      address = user.workforce.address;
+      
+    }
+
+    this.form.patchValue({
+      email: user.email,
+      address: address
+    });
+
+    this.form.get('email')?.disable();
+    this.form.get('address')?.disable();
+  });
+}
+
+
+  toggleEdit(field: 'email' | 'address'): void {
+    if (field === 'email') {
+      this.editingEmail = true;
+      this.form.get('email')?.enable();
+    } else if (field === 'address') {
+      this.editingAddress = true;
+      this.form.get('address')?.enable();
+    }
+  }
+
+  passwordMatchValidator(group: AbstractControl): { [key: string]: boolean } | null {
+    const newPass = group.get('newPassword')?.value;
+    const confirmPass = group.get('confirmPassword')?.value;
+    return newPass && confirmPass && newPass !== confirmPass ? { passwordMismatch: true } : null;
+  }
+
+  onFileChange(event: any): void {
+    const file = event.target.files[0];
+    if (file) {
+      this.selectedImageFile = file;
+
+      // Prévisualisation immédiate
+      const reader = new FileReader();
+      reader.onload = (e: any) => {
+        this.profilePreview = e.target.result;
+      };
+      reader.readAsDataURL(file);
+    }
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) return;
+
+    const formData = new FormData();
+
+    const email = this.form.getRawValue().email;
+    const address = this.form.getRawValue().address;
+
+    if (email) formData.append('email', email);
+    if (address) formData.append('address', address);
+
+    // Mots de passe (si modifiés)
+    if (this.form.value.newPassword) {
+      formData.append('password', this.form.value.newPassword);
+    }
+
+    // Fichier image sélectionné
+    if (this.selectedImageFile) {
+      formData.append('profileImage', this.selectedImageFile);
+    }
+
+    this.authService.updateUserProfile(formData).subscribe({
+      next: () => {
+        this.successMessage = '✅ Profile updated successfully!';
+        this.errorMessage = '';
+        this.editingEmail = false;
+        this.editingAddress = false;
+
+        // Reset password fields
+        this.form.get('oldPassword')?.reset();
+        this.form.get('newPassword')?.reset();
+        this.form.get('confirmPassword')?.reset();
+
+        // Réinitialiser les champs modifiables
+        this.form.get('email')?.disable();
+        this.form.get('address')?.disable();
+
+        setTimeout(() => this.successMessage = '', 4000);
+      },
+      error: (err) => {
+        this.errorMessage = '❌ Failed to update profile.';
+        this.successMessage = '';
+        console.error(err);
+        setTimeout(() => this.errorMessage = '', 5000);
+      }
+    });
+  }
+}

--- a/SLFrontend/src/app/home/navbar/navbar.component.html
+++ b/SLFrontend/src/app/home/navbar/navbar.component.html
@@ -50,7 +50,7 @@
       </li>
 
       <li class="profile-wrapper">
-        <a routerLink="/userprofile">
+        <a [routerLink]="profileLink">
           <img src="/icons/utilisateur.png" class="profile-icon" alt="Profile" />
         </a>
       </li>

--- a/SLFrontend/src/app/home/navbar/navbar.component.ts
+++ b/SLFrontend/src/app/home/navbar/navbar.component.ts
@@ -29,6 +29,12 @@ export class NavbarComponent implements OnInit, OnDestroy {
   showMessagesPopup = false;
   conversations: any[] = [];
   currentUser: any;
+  get profileLink(): string {
+    const role = this.currentUser?.role || this.authService.getUserRole();
+    if (role === '3rd Party') return '/helper-profile';
+    if (role === 'Super Admin') return '/admin-profile';
+    return '/client-profile';
+  }
   private pollInterval: any;
 
   @ViewChild('notificationWrapper') notificationWrapper!: ElementRef;

--- a/SLFrontend/src/main.ts
+++ b/SLFrontend/src/main.ts
@@ -23,7 +23,9 @@ import { ChatComponent } from './app/chat/chat.component';
 import { InvoiceComponent } from './app/helper-dashboard/invoice/invoice.component';
 import { InvoicesComponent } from './app/helper-dashboard/invoices/invoices.component';
 import { InvoiceDetailsComponent } from './app/helper-dashboard/invoice-details/invoice-details.component';
-import { UserProfileComponent } from './app/user-profile/user-profile.component';
+import { ClientProfileComponent } from './app/client-profile/client-profile.component';
+import { HelperProfileEditComponent } from './app/helper-profile-edit/helper-profile-edit.component';
+import { AdminProfileComponent } from './app/admin-profile/admin-profile.component';
 import { HelperProfileComponent } from './app/helper-profile/helper-profile.component';
 import { AdminDashboardComponent } from './app/admin-dashboard/admin-dashboard.component';
 import { AdminHelperViewComponent } from './app/admin-helper-view/admin-helper-view.component';
@@ -89,8 +91,10 @@ const routes: Routes = [
   { path: 'helper-signin', component: SigninhelperComponent },
   { path: 'application', component: SignuphelperComponent },
   { path: 'chat/:id', component: ChatComponent },
-  { path: 'userprofile', component: UserProfileComponent },
-  {path:'helper-profile/:id',component:HelperProfileComponent},
+  { path: 'client-profile', component: ClientProfileComponent },
+  { path: 'helper-profile', component: HelperProfileEditComponent },
+  { path: 'admin-profile', component: AdminProfileComponent },
+  { path: 'helper-profile/:id', component: HelperProfileComponent },
   { path: 'forgot-password', component: ForgotPasswordComponent },
    {
       path: 'admindashboard',


### PR DESCRIPTION
## Summary
- add separate components for client, helper and admin profiles
- display client's membership type in new client profile page
- add static monthly membership note in helper profile
- dynamically link profile pages in navbar based on role
- adjust password update logic to send correct field
- update routes to use new profile pages

## Testing
- `npm test --silent` *(fails: ng not found)*
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685d1cdd9a8883248044a9b4603f6cb0