### PR TITLE
Fix unauthorized message for chatbot endpoint

### DIFF
--- a/SwiftLink/chat/views.py
+++ b/SwiftLink/chat/views.py
@@ -40,10 +40,18 @@ def get_default_helper():
 
 
 class IsAuthenticatedWithMessage(IsAuthenticated):
-    """Custom permission with a clearer unauthenticated message."""
-    # When an unauthenticated user tries to interact with the chatbot,
-    # the API should respond with this message.
+    """Custom permission that returns a clearer unauthenticated message."""
+
     message = "Please log in to inquire about services."
+
+    def has_permission(self, request, view):
+        """Override to raise NotAuthenticated with our custom message."""
+        if request.user and request.user.is_authenticated:
+            return True
+
+        from rest_framework.exceptions import NotAuthenticated
+
+        raise NotAuthenticated(self.message)
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticatedWithMessage])


### PR DESCRIPTION
## Summary
- raise `NotAuthenticated` with clearer detail when hitting chatbot APIs without a token

## Testing
- `python SwiftLink/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_685d22d289e48324b986efc41a969949