### PR TITLE
Improve chat UX

### DIFF
--- a/SLFrontend/src/app/app.component.html
+++ b/SLFrontend/src/app/app.component.html
@@ -1,10 +1,12 @@
 <app-navbar></app-navbar>
 <router-outlet></router-outlet>
 <app-footer></app-footer>
-<app-chat
-  *ngIf="showPopup && popupData"
-  [conversationId]="popupData.conversationId"
-  [helperId]="popupData.helperId"
-  [orderId]="popupData.orderId"
-  (close)="closeChat()"
-></app-chat>
+<ng-container *ngFor="let popup of chatPopups; let i = index">
+  <app-chat
+    [conversationId]="popup.conversationId"
+    [helperId]="popup.helperId"
+    [orderId]="popup.orderId"
+    [index]="i"
+    (close)="closeChat(i)"
+  ></app-chat>
+</ng-container>

--- a/SLFrontend/src/app/app.component.ts
+++ b/SLFrontend/src/app/app.component.ts
@@ -17,24 +17,23 @@ import { environment } from '../environments/environment';
   styleUrl: './app.component.css'
 })
 export class AppComponent implements OnInit {
-  showPopup = false;
   private apiUrl = environment.apiUrl;
-  popupConversationId!: number;
   title = 'SLFrontend';
-  popupData: { conversationId: number, helperId: number, orderId: number } | null = null;
+  chatPopups: { conversationId: number; helperId: number; orderId: number }[] = [];
   ngOnInit(): void {
     this.http.get(`${this.apiUrl}/csrf/`, { withCredentials: true }).subscribe();
   }
 constructor(private commService: CommunicationService,private http: HttpClient) {
   this.commService.chatPopup$.subscribe(data => {
-    this.popupData = data;
-    this.showPopup = true;
+    const exists = this.chatPopups.find(p => p.conversationId === data.conversationId);
+    if (!exists) {
+      this.chatPopups.push(data);
+    }
   });
 }
 
-closeChat() {
-  this.showPopup = false;
-  this.popupData = null;
+closeChat(index: number) {
+  this.chatPopups.splice(index, 1);
 }
 }
 

--- a/SLFrontend/src/app/chat/chat.component.css
+++ b/SLFrontend/src/app/chat/chat.component.css
@@ -2,10 +2,10 @@
 .chat-popup {
   position: fixed;
   bottom: 20px;
-  right: 20px;
   width: 320px;
   height: 450px;
-  background-color: #ffffff;
+  background-color: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(4px);
   border-radius: 10px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
   display: flex;
@@ -17,7 +17,7 @@
 
 /* En-tête */
 .chat-header {
-  background-color: #002f5f;
+  background: linear-gradient(90deg, #004080, #002f5f);
   color: white;
   padding: 10px 14px;
   display: flex;

--- a/SLFrontend/src/app/chat/chat.component.html
+++ b/SLFrontend/src/app/chat/chat.component.html
@@ -1,4 +1,4 @@
-<div class="chat-popup">
+<div class="chat-popup" [style.right.px]="20 + index * 340">
   <div class="chat-header">
     <span>Chat</span>
     <button (click)="close.emit()">×</button>
@@ -41,7 +41,7 @@
   </div>
   
   <!-- Bouton Confirm pour le client uniquement -->
-  <div *ngIf="isClient" class="confirm-section">
+  <div *ngIf="isClient && orderStatus !== 'Booked'" class="confirm-section">
     <button class="confirm-btn" (click)="confirmOrder()">Confirm</button>
   </div>
   

--- a/SLFrontend/src/app/chat/chat.component.ts
+++ b/SLFrontend/src/app/chat/chat.component.ts
@@ -20,6 +20,7 @@ export class ChatComponent implements OnInit, OnDestroy {
 
   @Input() conversationId!: number;  // passed from <app-chat>
   @Input() helperId!: number;
+  @Input() index: number = 0;
   @Output() close = new EventEmitter<void>();
   currentUserId!: number;
   isClient:boolean=false;
@@ -28,6 +29,7 @@ export class ChatComponent implements OnInit, OnDestroy {
   defaultProfileImage: string = '/default-user.jpg';
   currentUser: any;
   private pollInterval: any;
+  orderStatus: string | null = null;
   
 
   constructor(private router: Router,private chatService: ChatService,private authService: AuthService,private orderService: OrderService)
@@ -37,6 +39,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     if (this.conversationId) {
       this.chatService.getConversation(this.conversationId).subscribe(data => {
         this.messages = data.messages;
+        this.orderStatus = data.order_status;
         // start polling for new messages
         this.startPolling();
       });
@@ -55,6 +58,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     this.pollInterval = setInterval(() => {
       this.chatService.getConversation(this.conversationId).subscribe(data => {
         this.messages = data.messages;
+        this.orderStatus = data.order_status;
       });
     }, 5000);
   }

--- a/SwiftLink/chat/serializers.py
+++ b/SwiftLink/chat/serializers.py
@@ -17,11 +17,21 @@ class ConversationSerializer(serializers.ModelSerializer):
     messages = MessageSerializer(many=True, read_only=True)
     client = UserSerializer(read_only=True)
     helper = UserSerializer(read_only=True)
-    order= serializers.IntegerField(source='order.orderID', read_only=True)
+    order = serializers.IntegerField(source='order.orderID', read_only=True)
+    order_status = serializers.CharField(source='order.jobStatus', read_only=True)
     unread_count = serializers.SerializerMethodField()
     class Meta:
         model = Conversation
-        fields = ['id', 'client', 'helper', 'created_at', 'messages','order','unread_count']
+        fields = [
+            'id',
+            'client',
+            'helper',
+            'created_at',
+            'messages',
+            'order',
+            'order_status',
+            'unread_count'
+        ]
 
     def get_unread_count(self, obj):
         request = self.context.get('request')


### PR DESCRIPTION
## Summary
- hide client confirm button once order is booked
- style chat popup and allow multiple chat windows
- expose order status in conversation API

## Testing
- `python manage.py test`
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: Error: Can't resolve './profile.component.scss?ngResource')*

------
https://chatgpt.com/codex/tasks/task_b_685d26b1f8248324a0cfcfe216083cd9