### PR TITLE
Fix chat popup click handler

### DIFF
--- a/SLFrontend/src/app/home/navbar/navbar.component.html
+++ b/SLFrontend/src/app/home/navbar/navbar.component.html
@@ -26,7 +26,7 @@
         <div *ngIf="showMessagesPopup" class="messages-popup">
           <div *ngIf="conversations.length === 0">No messages</div>
           <ul *ngIf="conversations.length > 0">
-            <li *ngFor="let conv of conversations" (click)="openChat(conv.id, conv.helper, conv.order)">
+            <li *ngFor="let conv of conversations" (click)="openChat($event, conv.id, conv.helper.user_id, conv.order)">
               You have a discussion with {{ getOtherUserName(conv) }}
               <span *ngIf="conv.unread_count > 0" class="unread-label">Unread message</span>
             </li>

--- a/SLFrontend/src/app/home/navbar/navbar.component.ts
+++ b/SLFrontend/src/app/home/navbar/navbar.component.ts
@@ -171,7 +171,8 @@ export class NavbarComponent implements OnInit, OnDestroy {
     });
   }
 
-  openChat(conversationId: number, helperId: number, orderId: number) {
+  openChat(event: MouseEvent, conversationId: number, helperId: number, orderId: number) {
+    event.stopPropagation();
     this.showMessagesPopup = false;
     this.communicationService.openChatPopup({ conversationId, helperId, orderId });
     this.loadUnreadMessages();


### PR DESCRIPTION
## Summary
- ensure conversation click passes helper ID instead of entire helper object

## Testing
- `npx --prefix SLFrontend ng test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_b_685d2b12e99883249c00a644686fa12f