### PR TITLE
Improve notifications and chat UI

### DIFF
--- a/SLFrontend/src/app/chat/chat.component.ts
+++ b/SLFrontend/src/app/chat/chat.component.ts
@@ -40,6 +40,9 @@ export class ChatComponent implements OnInit, OnDestroy {
       this.chatService.getConversation(this.conversationId).subscribe(data => {
         this.messages = data.messages;
         this.orderStatus = data.order_status;
+        if (this.orderStatus === 'Booked') {
+          this.appendConfirmationMessage();
+        }
         // start polling for new messages
         this.startPolling();
       });
@@ -59,6 +62,9 @@ export class ChatComponent implements OnInit, OnDestroy {
       this.chatService.getConversation(this.conversationId).subscribe(data => {
         this.messages = data.messages;
         this.orderStatus = data.order_status;
+        if (this.orderStatus === 'Booked') {
+          this.appendConfirmationMessage();
+        }
       });
     }, 5000);
   }
@@ -72,10 +78,8 @@ export class ChatComponent implements OnInit, OnDestroy {
     if (!this.conversationId) return;
     this.orderConfirmed = true;
 
-  this.messages.push({
-    content: "Your order has been confirmed",
-    system: true // tu peux utiliser ce flag pour les messages spéciaux
-  });
+  this.orderStatus = 'Booked';
+  this.appendConfirmationMessage();
     this.orderService.confirmOrderAssignment(this.conversationId).subscribe({
       next: (res) => {
         if (res.success) {
@@ -102,6 +106,13 @@ export class ChatComponent implements OnInit, OnDestroy {
       });
       this.messageText = '';
     });
+  }
+
+  private appendConfirmationMessage() {
+    const exists = this.messages.some(m => m.system && m.content === 'Your order has been confirmed');
+    if (!exists) {
+      this.messages.push({ content: 'Your order has been confirmed', system: true });
+    }
   }
   goToHelperProfile(helperId: number) {
   this.router.navigate(['/helper-profile', helperId]);

--- a/SLFrontend/src/app/home/navbar/navbar.component.ts
+++ b/SLFrontend/src/app/home/navbar/navbar.component.ts
@@ -168,6 +168,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
     this.chatService.startConversation(helperId, orderId).subscribe(res => {
       const conversationId = res.conversation_id;
       this.communicationService.openChatPopup({ conversationId, helperId, orderId });
+      this.router.navigate(['/helper-profile', helperId]);
     });
   }
 

--- a/SwiftLink/Order/views.py
+++ b/SwiftLink/Order/views.py
@@ -33,7 +33,7 @@ class LikeOrderView(APIView):
             order.save()
 
             # ✅ Create a notification with full context
-            message = f"{helper.username} is interested to help you!"
+            message = f"{helper.first_name} is interested to help you! Click to start the conversation"
             Notification.objects.create(
                 user=order.clientID.UserId,         # The client
                 message=message,


### PR DESCRIPTION
## Summary
- display helper first name in order like notifications
- open helper profile when clicking on a notification
- keep confirmation message visible in chat when an order is confirmed

## Testing
- `npm test` *(fails: ng not found)*
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685d31b123a48324999ca59c114ab78d