### PR TITLE
Display booked orders on invoices page

### DIFF
--- a/SLFrontend/src/app/client-invoices/client-invoices.component.css
+++ b/SLFrontend/src/app/client-invoices/client-invoices.component.css
@@ -14,3 +14,16 @@
 .invoice-list li:hover {
   background-color: #f0f0f0;
 }
+
+.scheduled-orders {
+  max-width: 600px;
+  margin: 20px auto;
+}
+.scheduled-orders ul {
+  list-style: none;
+  padding: 0;
+}
+.scheduled-orders li {
+  padding: 10px;
+  border-bottom: 1px solid #ccc;
+}

--- a/SLFrontend/src/app/client-invoices/client-invoices.component.html
+++ b/SLFrontend/src/app/client-invoices/client-invoices.component.html
@@ -1,3 +1,14 @@
+<div class="scheduled-orders">
+  <h2>Scheduled Work Orders</h2>
+  <ul>
+    <li *ngFor="let order of bookedOrders">
+      {{ order.status }} - {{ order.address }} -
+      {{ order.executionDate | date:'mediumDate' }} -
+      {{ order.helperName || 'N/A' }}
+    </li>
+  </ul>
+</div>
+<hr />
 <div class="invoice-list">
   <h2>Your Invoices</h2>
   <ul>

--- a/SLFrontend/src/app/client-invoices/client-invoices.component.ts
+++ b/SLFrontend/src/app/client-invoices/client-invoices.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { CommonModule, NgFor } from '@angular/common';
 import { InvoiceService } from '../services/invoice.service';
+import { OrderService } from '../services/order.service';
 
 @Component({
   selector: 'app-client-invoices',
@@ -12,12 +13,21 @@ import { InvoiceService } from '../services/invoice.service';
 })
 export class ClientInvoicesComponent implements OnInit {
   invoices: any[] = [];
+  bookedOrders: any[] = [];
 
-  constructor(private invoiceService: InvoiceService, private router: Router) {}
+  constructor(
+    private invoiceService: InvoiceService,
+    private orderService: OrderService,
+    private router: Router
+  ) {}
 
   ngOnInit() {
     this.invoiceService.getClientInvoices().subscribe(data => {
       this.invoices = data;
+    });
+
+    this.orderService.getClientBookedOrders().subscribe(data => {
+      this.bookedOrders = data;
     });
   }
 

--- a/SLFrontend/src/app/services/order.service.ts
+++ b/SLFrontend/src/app/services/order.service.ts
@@ -72,6 +72,20 @@ export class OrderService {
     return this.http.get<any[]>(`${this.apiUrl}today/`);
   }
 
+  getClientBookedOrders(): Observable<any[]> {
+    const token = localStorage.getItem('access_token');
+    if (!token) {
+      console.error('No access token found!');
+      return new Observable<any[]>();
+    }
+
+    const headers = new HttpHeaders({
+      Authorization: `Bearer ${token}`
+    });
+
+    return this.http.get<any[]>(`${this.apiUrl}client-booked/`, { headers });
+  }
+
   getWorkOrdersDashboard() {
     const token = localStorage.getItem('access_token');
     if (!token) {

--- a/SwiftLink/Order/urls.py
+++ b/SwiftLink/Order/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path('orders/today/', views.orders_today),
     path('dashboard/helper/', views.helper_dashboard),
     path('dashboard/work-orders/', views.work_orders_dashboard),
+    path('orders/client-booked/', views.client_booked_orders),
 ]


### PR DESCRIPTION
## Summary
- allow client to fetch their booked orders via API
- expose new endpoint `/orders/client-booked/`
- support API in the Angular service
- show list of booked orders above invoices

## Testing
- `pytest`
- `npx tsc -p tsconfig.json`
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_685d6ee125b48324b48aae7b013a7d3e