### PR TITLE
Enable sending chat message with Enter

### DIFF
--- a/SLFrontend/src/app/chat/chat.component.html
+++ b/SLFrontend/src/app/chat/chat.component.html
@@ -47,7 +47,10 @@
   
 
   <div class="input-bar">
-    <input [(ngModel)]="messageText" placeholder="Type a message..." />
+    <input
+      [(ngModel)]="messageText"
+      placeholder="Type a message..."
+      (keyup.enter)="send()" />
     <button (click)="send()">Send</button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- allow sending chat messages using the Enter key

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_685e73861c488324a49b36adfe8b592b