### PR TITLE
Fix message send serialization and clear chat input

### DIFF
--- a/SLFrontend/src/app/chat/chat.component.ts
+++ b/SLFrontend/src/app/chat/chat.component.ts
@@ -95,16 +95,17 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
   send() {
     if (!this.messageText.trim()) return;
-    
-    
-    this.chatService.sendMessage(this.conversationId, this.messageText,this.currentUserId).subscribe(() => {
+
+    const content = this.messageText;
+    this.messageText = '';
+
+    this.chatService.sendMessage(this.conversationId, content, this.currentUserId).subscribe(() => {
       this.messages.push({
-        content: this.messageText,
+        content,
         sender: this.currentUserId,
         senderImage: this.currentUser?.profileImage || this.defaultProfileImage,
         timestamp: new Date()
       });
-      this.messageText = '';
     });
   }
 

--- a/SwiftLink/chat/views.py
+++ b/SwiftLink/chat/views.py
@@ -94,7 +94,7 @@ def get_conversation(request, conversation_id):
 @api_view(['POST'])
 @permission_classes([IsAuthenticatedWithMessage])
 def send_message(request):
-    serializer = MessageSerializer(data=request.data)
+    serializer = MessageSerializer(data=request.data, context={'request': request})
     if serializer.is_valid():
         serializer.save(sender=request.user)
         return Response(serializer.data)


### PR DESCRIPTION
## Summary
- pass request context to `MessageSerializer` in `send_message`
- clear chat input before calling the API so the field resets immediately

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e78af8aac8324a56616490f996cb1