### PR TITLE
Fix agenda details layout

### DIFF
--- a/SLFrontend/src/app/helper-dashboard/agenda/agenda.component.css
+++ b/SLFrontend/src/app/helper-dashboard/agenda/agenda.component.css
@@ -3,6 +3,7 @@
     gap: 30px;
     padding: 30px;
     font-family: 'Segoe UI', sans-serif;
+    flex-wrap: wrap; /* allow wrapping on smaller screens */
   }
   
   /* Calendrier */
@@ -125,10 +126,11 @@
     cursor: not-allowed;
   }
 
-  .order-details {
-    margin-top: 20px;
+.order-details {
+    margin: 0 0 20px 0;
     background: #fff;
     padding: 20px;
     border-radius: 10px;
     box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+    width: 100%;
   }

--- a/SLFrontend/src/app/helper-dashboard/agenda/agenda.component.html
+++ b/SLFrontend/src/app/helper-dashboard/agenda/agenda.component.html
@@ -7,6 +7,15 @@
   <div class="jobs-today">
     <h3>Today's Jobs</h3>
 
+    <div class="order-details" *ngIf="detailOrder">
+      <h3>Order Details</h3>
+      <p><strong>Title:</strong> {{ detailOrder.jobTitle }}</p>
+      <p><strong>Address:</strong> {{ detailOrder.jobAddress }}</p>
+      <p><strong>Date:</strong> {{ detailOrder.executionDate | date:'short' }}</p>
+      <p><strong>Client:</strong> {{ detailOrder.clientName }}</p>
+      <p><strong>Phone:</strong> {{ detailOrder.clientPhone }}</p>
+    </div>
+
     <div class="job-card" *ngFor="let job of todayJobs" (click)="showDetails(job)">
       <p><strong>{{ job.jobTitle }}</strong></p>
       <p>⏰ {{ job.executionDate | date:'shortTime' }}</p>
@@ -36,12 +45,4 @@
     </div>
   </div>
 
-  <div class="order-details" *ngIf="detailOrder">
-    <h3>Order Details</h3>
-    <p><strong>Title:</strong> {{ detailOrder.jobTitle }}</p>
-    <p><strong>Address:</strong> {{ detailOrder.jobAddress }}</p>
-    <p><strong>Date:</strong> {{ detailOrder.executionDate | date:'short' }}</p>
-    <p><strong>Client:</strong> {{ detailOrder.clientName }}</p>
-    <p><strong>Phone:</strong> {{ detailOrder.clientPhone }}</p>
-  </div>
 </div>

--- a/SLFrontend/src/app/helper-dashboard/agenda/agenda.component.ts
+++ b/SLFrontend/src/app/helper-dashboard/agenda/agenda.component.ts
@@ -1,5 +1,5 @@
 import { Component, NgModule, OnInit } from '@angular/core';
-import { CalendarOptions} from '@fullcalendar/core';
+import { CalendarOptions, EventClickArg } from '@fullcalendar/core';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import { CommonModule } from '@angular/common';
@@ -25,7 +25,8 @@ export class AgendaComponent implements OnInit {
       left: 'prev,next today',
       center: 'title',
       right: 'dayGridMonth'
-    }
+    },
+    eventClick: this.onCalendarEventClick.bind(this)
   };
   selectedOrder: Order | null = null;
   startTime: Date | null = null;
@@ -45,7 +46,8 @@ export class AgendaComponent implements OnInit {
         title: order.jobTitle,
         date: order.executionDate,
         extendedProps: {
-          address: order.jobAddress
+          address: order.jobAddress,
+          order: order
         }
       }));
     });
@@ -61,6 +63,20 @@ export class AgendaComponent implements OnInit {
 
   showDetails(job: any) {
     this.detailOrder = job;
+  }
+
+  onCalendarEventClick(arg: EventClickArg) {
+    const order = arg.event.extendedProps['order'];
+    if (order) {
+      this.detailOrder = order;
+    } else {
+      // Fallback: build minimal order from event data
+      this.detailOrder = {
+        jobTitle: arg.event.title,
+        executionDate: arg.event.start,
+        jobAddress: arg.event.extendedProps['address']
+      };
+    }
   }
   startJob(job: Order) {
     this.selectedOrder = job;


### PR DESCRIPTION
## Summary
- connect calendar clicks to order details
- show order details above today's job list
- tweak order detail panel sizing for new layout

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e834c470883249d7efe0593e7dfbd