### PR TITLE
Update invoice fees and confirm status changes

### DIFF
--- a/SLFrontend/src/app/helper-dashboard/invoice-details/invoice-details.component.html
+++ b/SLFrontend/src/app/helper-dashboard/invoice-details/invoice-details.component.html
@@ -2,7 +2,7 @@
   <h2>Invoice #{{ invoice.invoiceID }}</h2>
   <p>ISF contribution (10%): {{ isf | number:'1.2-2' }} $ CAD</p>
   <p>Platform fee (10%): {{ platformFee | number:'1.2-2' }} $ CAD</p>
-  <p *ngIf="payPerUse">Pay-per-use fee: {{ payPerUse }} $ CAD</p>
+  <p *ngIf="membershipFee">Membership fee: {{ membershipFee }} $ CAD</p>
   <p>Total due: {{ totalDue | number:'1.2-2' }} $ CAD</p>
   <div class="payment-box">
     send e-Transfer to : platform.fee&#64;swift-link.ca<br />

--- a/SLFrontend/src/app/helper-dashboard/invoice-details/invoice-details.component.ts
+++ b/SLFrontend/src/app/helper-dashboard/invoice-details/invoice-details.component.ts
@@ -14,7 +14,7 @@ export class InvoiceDetailsComponent implements OnInit {
   invoice: any;
   isf = 0;
   platformFee = 0;
-  payPerUse = 0;
+  membershipFee = 0;
   totalDue = 0;
 
   constructor(private route: ActivatedRoute, private invoiceService: InvoiceService) {}
@@ -30,11 +30,41 @@ export class InvoiceDetailsComponent implements OnInit {
   }
 
   calculateFees() {
-    const amount = parseFloat(this.invoice.totalAmount);
-    this.isf = amount * 0.10;
-    this.platformFee = amount * 0.10;
-    const ppu = this.invoice.extras?.find((e: any) => e.label === 'Pay-per-use Fee');
-    this.payPerUse = ppu ? parseFloat(ppu.price) : 0;
-    this.totalDue = amount + this.isf + this.platformFee;
+    const hours = this.durationToHours(this.invoice.duration);
+    const rate = parseFloat(this.invoice.unitPrice);
+    this.isf = rate * hours * 0.10;
+    this.platformFee = rate * hours * 0.10;
+
+    const membershipLabels = [
+      'Pay-per-use Fee',
+      'pay-per-use',
+      'Preferred Member- Unlimited bookings',
+      'Ultimate Member- Unlimited bookings'
+    ];
+    const membership = this.invoice.extras?.find((e: any) => membershipLabels.includes(e.label));
+    this.membershipFee = membership ? parseFloat(membership.price) : 0;
+
+    this.totalDue = this.isf + this.platformFee + this.membershipFee;
+  }
+
+  private durationToHours(duration?: string | number | null): number {
+    if (duration == null) {
+      return 0;
+    }
+    if (typeof duration === 'number') {
+      return duration;
+    }
+    let days = 0;
+    let timePart = duration;
+    const dayMatch = duration.match(/^(\d+)\s+/);
+    if (dayMatch) {
+      days = parseInt(dayMatch[1], 10);
+      timePart = duration.substring(dayMatch[0].length);
+    }
+    const parts = timePart.split(":");
+    const h = parseInt(parts[0], 10) || 0;
+    const m = parseInt(parts[1], 10) || 0;
+    const s = parseInt(parts[2], 10) || 0;
+    return days * 24 + h + m / 60 + s / 3600;
   }
 }

--- a/SLFrontend/src/app/helper-dashboard/invoices/invoices.component.ts
+++ b/SLFrontend/src/app/helper-dashboard/invoices/invoices.component.ts
@@ -24,12 +24,24 @@ export class InvoicesComponent implements OnInit {
 
   ngOnInit() {
     this.invoiceService.getHelperInvoices().subscribe(data => {
-      this.invoices = data;
+      this.invoices = data.map(inv => ({ ...inv, previousStatus: inv.status }));
     });
   }
 
   updateStatus(inv: any) {
-    this.invoiceService.updateInvoiceStatus(inv.invoiceID, inv.status).subscribe();
+    const newStatus = inv.status;
+    if (confirm(`Confirm changing status to "${newStatus}"?`)) {
+      this.invoiceService.updateInvoiceStatus(inv.invoiceID, newStatus).subscribe({
+        next: () => {
+          inv.previousStatus = newStatus;
+        },
+        error: () => {
+          inv.status = inv.previousStatus;
+        }
+      });
+    } else {
+      inv.status = inv.previousStatus;
+    }
   }
 
   viewInvoice(inv: any) {


### PR DESCRIPTION
## Summary
- prompt user before changing invoice status
- show membership fee and update fee calculations for helper invoice view

## Testing
- `python manage.py test`
- `npx ng test --watch=false` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_b_6860ffd19e3083248a98c8b01e93cc43