### PR TITLE
Add Mountain time handling to chat order creation

### DIFF
--- a/SwiftLink/SwiftLink/settings.py
+++ b/SwiftLink/SwiftLink/settings.py
@@ -132,7 +132,8 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+# Use Mountain Time zone for all date/time handling
+TIME_ZONE = 'America/Denver'
 
 USE_I18N = True
 


### PR DESCRIPTION
## Summary
- set project timezone to `America/Denver`
- update chat prompt to request execution time and specify Mountain Time
- parse execution datetime into Mountain timezone when creating orders

## Testing
- `python -m compileall -q SwiftLink/chat/views.py SwiftLink/SwiftLink/settings.py`


------
https://chatgpt.com/codex/tasks/task_b_68639552b5388324a34441c297f47801