### PR TITLE
Show unified sign in error

### DIFF
--- a/SLFrontend/src/app/auth/signin/signin.component.ts
+++ b/SLFrontend/src/app/auth/signin/signin.component.ts
@@ -57,7 +57,18 @@ export class SigninComponent implements OnInit {
       } 
     },
     error: (err) => {
-      this.errorMessage = err?.error?.error || 'An error occurred, please try again.';
+      const nonField = err.error?.non_field_errors;
+      if (
+        (Array.isArray(nonField) &&
+          (nonField.includes('Invalid credentials.') ||
+           nonField.includes('Invalid credentials') ||
+           nonField.includes('User not found.')))
+        || err.error?.error === 'Invalid credentials'
+      ) {
+        this.errorMessage = 'Email or password are wrong, try again.';
+      } else {
+        this.errorMessage = err?.error?.error || 'An error occurred, please try again.';
+      }
     }
   });
 }

--- a/SLFrontend/src/app/auth/signinclient/signinclient.component.ts
+++ b/SLFrontend/src/app/auth/signinclient/signinclient.component.ts
@@ -50,7 +50,18 @@ login() {
       } 
     },
     error: (err) => {
-      this.errorMessage = err?.error?.error || 'An error occurred, please try again.';
+      const nonField = err.error?.non_field_errors;
+      if (
+        (Array.isArray(nonField) &&
+          (nonField.includes('Invalid credentials.') ||
+           nonField.includes('Invalid credentials') ||
+           nonField.includes('User not found.')))
+        || err.error?.error === 'Invalid credentials'
+      ) {
+        this.errorMessage = 'Email or password are wrong, try again.';
+      } else {
+        this.errorMessage = err?.error?.error || 'An error occurred, please try again.';
+      }
     }
   });
 }

--- a/SLFrontend/src/app/auth/signinhelper/signinhelper.component.ts
+++ b/SLFrontend/src/app/auth/signinhelper/signinhelper.component.ts
@@ -52,7 +52,18 @@ export class SigninhelperComponent {
       }
     },
     error: (err) => {
-      this.errorMessage = err?.error?.error || 'An error occurred, please try again.';
+      const nonField = err.error?.non_field_errors;
+      if (
+        (Array.isArray(nonField) &&
+          (nonField.includes('Invalid credentials.') ||
+           nonField.includes('Invalid credentials') ||
+           nonField.includes('User not found.')))
+        || err.error?.error === 'Invalid credentials'
+      ) {
+        this.errorMessage = 'Email or password are wrong, try again.';
+      } else {
+        this.errorMessage = err?.error?.error || 'An error occurred, please try again.';
+      }
     }
   });
 }

--- a/SLFrontend/src/app/office-dashboard/office-dashboard.component.ts
+++ b/SLFrontend/src/app/office-dashboard/office-dashboard.component.ts
@@ -62,7 +62,18 @@ export class OfficeDashboardComponent implements OnInit {
         this.isLoggedIn = true;
       },
       error: (err) => {
-        this.errorMessage = err?.error?.error || 'An error occurred, please try again.';
+        const nonField = err.error?.non_field_errors;
+        if (
+          (Array.isArray(nonField) &&
+            (nonField.includes('Invalid credentials.') ||
+             nonField.includes('Invalid credentials') ||
+             nonField.includes('User not found.')))
+          || err.error?.error === 'Invalid credentials'
+        ) {
+          this.errorMessage = 'Email or password are wrong, try again.';
+        } else {
+          this.errorMessage = err?.error?.error || 'An error occurred, please try again.';
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- show a consistent error message if credentials are invalid for all login screens

## Testing
- `python SwiftLink/manage.py test`
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863972c1054832496bc55de6f1f202d