### PR TITLE
Add resume upload field

### DIFF
--- a/SLFrontend/src/app/helper-form/helper-form.component.html
+++ b/SLFrontend/src/app/helper-form/helper-form.component.html
@@ -58,6 +58,9 @@
     <label>Social Security Number</label>
     <input type="text" name="socialSecurityNumber" [(ngModel)]="form.socialSecurityNumber" />
 
+    <label>Upload Resume</label>
+    <input type="file" (change)="onFileSelect($event, 'resume')" />
+
 <p>2. Address and Profile Details</p>
     <!-- Profile Photo -->
 <label>Upload Profile Photo</label>

--- a/SLFrontend/src/app/helper-form/helper-form.component.ts
+++ b/SLFrontend/src/app/helper-form/helper-form.component.ts
@@ -15,9 +15,10 @@ import { LogarithmicScale } from 'chart.js';
 export class HelperFormComponent implements OnInit {
   errorMessage: string = '';
    showContract = false;
-form: any = {
-  country: 'Canada'  // valeur par défaut
-};
+ form: any = {
+  country: 'Canada',  // valeur par défaut
+  resume: null
+ };
   files: { [key: string]: File } = {};
 emailError: string = '';
 passwordError: string = '';
@@ -110,7 +111,7 @@ calculateRates() {
     }
   });
 }
-onFileSelect(event: Event, field: 'profileImage' | 'driverLicenceFile' | 'wcbFile'): void {
+onFileSelect(event: Event, field: 'profileImage' | 'driverLicenceFile' | 'wcbFile' | 'resume'): void {
   const input = event.target as HTMLInputElement;
   if (input.files && input.files.length > 0) {
     const file = input.files[0];

--- a/SwiftLink/Workforce/Serializers.py
+++ b/SwiftLink/Workforce/Serializers.py
@@ -54,6 +54,7 @@ class WorkforceProfileCompletionSerializer(serializers.ModelSerializer):
     first_name = serializers.CharField(source='UserId.first_name', required=False)
     last_name = serializers.CharField(source='UserId.last_name', required=False)
     password = serializers.CharField(source='UserId.password', write_only=True, required=False)
+    resume = serializers.FileField(required=False)
     
     class Meta:
         model = WorkForce
@@ -63,6 +64,7 @@ class WorkforceProfileCompletionSerializer(serializers.ModelSerializer):
             'first_name',
             'last_name',
             'password',
+            'resume',
             'driverLicence', 'driverLicenceExpiry', 'driverLicenceFile',
             'wcbNumber', 'wcbFile',
             'address', 'city', 'province', 'postalCode', 'country',


### PR DESCRIPTION
## Summary
- support resume files in workforce profile completion
- allow resume upload field in the helper profile form

## Testing
- `npm test` *(fails: ng not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686399c2731483248a639e802fc00401