### PR TITLE
Remove resume from signup helper

### DIFF
--- a/SLFrontend/src/app/auth/signuphelper/signuphelper.component.html
+++ b/SLFrontend/src/app/auth/signuphelper/signuphelper.component.html
@@ -59,8 +59,6 @@ environments. *</label>
     <label class="label-title">Work Profile</label>
     <textarea name="training" [(ngModel)]="workforceForm.training" rows="3" placeholder="Work Experience *" required></textarea>
     <textarea name="yearsOfExperience" [(ngModel)]="workforceForm.yearsOfExperience" rows="2" placeholder="Years of Relevant Experience *" required></textarea>
-    <label>Resume</label>
-    <input type="file" name="resume" (change)="onFileChange($event, 'resume')" />
 
     <!-- 4. Mobility -->
     <label class="label-title">Mobility</label>

--- a/SLFrontend/src/app/auth/signuphelper/signuphelper.component.ts
+++ b/SLFrontend/src/app/auth/signuphelper/signuphelper.component.ts
@@ -42,7 +42,6 @@ vehicleOptions = {
     credentialsExpiry: '',
     training: '',
     yearsOfExperience: '',
-    resume: null,
     workForceType: WorkForceType.EMPLOYEE,
     dateOfBirth: '',
     socialSecurityNumber: '',
@@ -120,12 +119,6 @@ onVehicleSelect(event: Event, type: 'vehicle' | 'tool'): void {
 }
 
 
-  onFileChange(event: any, field: string): void {
-    const file = event.target.files[0];
-    if (file) {
-      this.workforceForm[field] = file;
-    }
-  }
 
  register(): void {
   if (!this.acceptedPolicy || !this.workforceForm.firstName || !this.workforceForm.training) {


### PR DESCRIPTION
## Summary
- remove resume upload field from `SignuphelperComponent`
- clean up workforce form to drop resume property and file handler

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_b_6863a484b0b083249778a723319c9428