### PR TITLE
Add responsive navbar for mobile

### DIFF
--- a/SLFrontend/src/app/home/navbar/navbar.component.css
+++ b/SLFrontend/src/app/home/navbar/navbar.component.css
@@ -206,4 +206,27 @@
   transform: scale(1.05);
 }
 
+.navbar-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: white;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .navbar-toggle {
+    display: block;
+  }
+  .nav-links {
+    flex-direction: column;
+    width: 100%;
+    display: none;
+  }
+  .nav-links.active {
+    display: flex;
+  }
+}
+
 

--- a/SLFrontend/src/app/home/navbar/navbar.component.html
+++ b/SLFrontend/src/app/home/navbar/navbar.component.html
@@ -2,8 +2,9 @@
   <div class="logo" (click)="redirectByRole()" style="cursor: pointer;">
     <img src="/logo.png" alt="Swift Helpers Logo" class="logo-img">
   </div>
+  <button class="navbar-toggle" (click)="toggleMenu()">&#9776;</button>
 
-  <ul class="nav-links">
+  <ul class="nav-links" [class.active]="menuOpen">
     <li><a (click)="redirectByRole()">Home</a></li>
        <li *ngIf="currentUser?.role !== '3rd Party' && currentUser?.role !== 'Super Admin'">
     <a routerLink="/services">Services</a>

--- a/SLFrontend/src/app/home/navbar/navbar.component.ts
+++ b/SLFrontend/src/app/home/navbar/navbar.component.ts
@@ -29,6 +29,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
   showMessagesPopup = false;
   conversations: any[] = [];
   currentUser: any;
+  menuOpen = false;
   get profileLink(): string {
     const role = this.currentUser?.role || this.authService.getUserRole();
     if (role === '3rd Party') return '/helper-profile';
@@ -116,6 +117,10 @@ export class NavbarComponent implements OnInit, OnDestroy {
       clearInterval(this.pollInterval);
       this.pollInterval = null;
     }
+  }
+
+  toggleMenu() {
+    this.menuOpen = !this.menuOpen;
   }
 
   toggleNotificationPopup(event: MouseEvent) {

--- a/SLFrontend/src/styles.css
+++ b/SLFrontend/src/styles.css
@@ -10,10 +10,16 @@
     color: #333;
   }
   
+.container {
+  max-width: 1200px;
+  margin: auto;
+  padding: 0 20px;
+}
+head{font-family: 'Open Sans', sans-serif;
+}
+
+@media (max-width: 768px) {
   .container {
-    max-width: 1200px;
-    margin: auto;
-    padding: 0 20px;
+    padding: 0 10px;
   }
-  head{font-family: 'Open Sans', sans-serif;
-  }
+}


### PR DESCRIPTION
## Summary
- add hamburger menu toggle to navbar
- hide/show links on smaller screens
- tweak global styles for small screens

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863a751593c832494d8485908a3ac1e